### PR TITLE
Implemented a post filtering system in `ForumFragment` to allow users…

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumFragment.java
+++ b/app/src/main/java/com/birddex/app/ForumFragment.java
@@ -1,6 +1,8 @@
 package com.birddex.app;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -26,6 +28,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 
@@ -39,11 +42,16 @@ import java.util.List;
 public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostClickListener {
 
     private static final String TAG = "ForumFragment";
+    private static final String PREFS_NAME = "ForumPrefs";
+    private static final String KEY_FILTER = "current_filter";
+    
     private FragmentForumBinding binding;
     private FirebaseAuth mAuth;
     private FirebaseFirestore db;
     private FirebaseManager firebaseManager;
     private ForumPostAdapter adapter;
+    private ListenerRegistration postsListener;
+    private String currentFilter = "Recent";
 
     @Nullable
     @Override
@@ -57,10 +65,14 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
         db = FirebaseFirestore.getInstance();
         firebaseManager = new FirebaseManager(requireContext());
 
+        // Load saved filter preference
+        SharedPreferences prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        currentFilter = prefs.getString(KEY_FILTER, "Recent");
+
         setupRecyclerView();
         setupClickListeners();
         loadUserProfilePicture();
-        listenForPosts();
+        applyFilter(); // Load initial data based on saved filter
 
         return view;
     }
@@ -80,6 +92,41 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
         binding.btnSocial.setOnClickListener(v -> {
             startActivity(new Intent(getActivity(), SocialActivity.class));
         });
+
+        binding.btnFilter.setOnClickListener(this::showFilterMenu);
+    }
+
+    private void showFilterMenu(View v) {
+        PopupMenu popup = new PopupMenu(getContext(), v);
+        popup.getMenu().add("Recent");
+        popup.getMenu().add("Following");
+
+        popup.setOnMenuItemClickListener(item -> {
+            String selectedFilter = item.getTitle().toString();
+            if (!selectedFilter.equals(currentFilter)) {
+                currentFilter = selectedFilter;
+                
+                // Save filter preference
+                SharedPreferences prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+                prefs.edit().putString(KEY_FILTER, currentFilter).apply();
+                
+                applyFilter();
+            }
+            return true;
+        });
+        popup.show();
+    }
+
+    private void applyFilter() {
+        if (postsListener != null) {
+            postsListener.remove();
+        }
+        
+        if ("Following".equals(currentFilter)) {
+            listenForFollowingPosts();
+        } else {
+            listenForPosts();
+        }
     }
 
     private void loadUserProfilePicture() {
@@ -103,9 +150,7 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
     }
 
     private void listenForPosts() {
-        // addSnapshotListener with MetadataChanges.INCLUDE allows us to see when data 
-        // is coming from the local cache vs the server.
-        db.collection("forumThreads")
+        postsListener = db.collection("forumThreads")
                 .orderBy("timestamp", Query.Direction.DESCENDING)
                 .addSnapshotListener(MetadataChanges.INCLUDE, (value, error) -> {
                     if (!isAdded() || binding == null) return;
@@ -115,25 +160,72 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
                     }
 
                     if (value != null) {
-                        List<ForumPost> posts = new ArrayList<>();
-                        for (DocumentSnapshot doc : value.getDocuments()) {
-                            ForumPost post = doc.toObject(ForumPost.class);
-                            if (post != null) {
-                                post.setId(doc.getId());
-                                posts.add(post);
-                            }
-                        }
-                        adapter.setPosts(posts);
-                        
-                        // If data is from cache, it's already shown! 
-                        // If it's from server, the list will update smoothly.
-                        if (value.getMetadata().isFromCache()) {
-                            Log.d(TAG, "Forum data loaded from local cache");
-                        } else {
-                            Log.d(TAG, "Forum data synchronized with server");
-                        }
+                        processSnapshot(value.getDocuments(), value.getMetadata().isFromCache());
                     }
                 });
+    }
+
+    private void listenForFollowingPosts() {
+        FirebaseUser currentUser = mAuth.getCurrentUser();
+        if (currentUser == null) return;
+
+        db.collection("users").document(currentUser.getUid()).collection("following")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    if (!isAdded() || binding == null) return;
+                    
+                    List<String> followedIds = new ArrayList<>();
+                    for (DocumentSnapshot doc : queryDocumentSnapshots.getDocuments()) {
+                        followedIds.add(doc.getId());
+                    }
+
+                    if (followedIds.isEmpty()) {
+                        adapter.setPosts(new ArrayList<>());
+                        Toast.makeText(getContext(), "You are not following anyone yet.", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    // Firestore whereIn limit is 30. For simplicity, we use the first 30.
+                    if (followedIds.size() > 30) {
+                        followedIds = followedIds.subList(0, 30);
+                    }
+
+                    postsListener = db.collection("forumThreads")
+                            .whereIn("userId", followedIds)
+                            .orderBy("timestamp", Query.Direction.DESCENDING)
+                            .addSnapshotListener(MetadataChanges.INCLUDE, (value, error) -> {
+                                if (!isAdded() || binding == null) return;
+                                if (error != null) {
+                                    Log.e(TAG, "Following listen failed.", error);
+                                    return;
+                                }
+
+                                if (value != null) {
+                                    processSnapshot(value.getDocuments(), value.getMetadata().isFromCache());
+                                }
+                            });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error fetching following list", e);
+                });
+    }
+
+    private void processSnapshot(List<DocumentSnapshot> documents, boolean isFromCache) {
+        List<ForumPost> posts = new ArrayList<>();
+        for (DocumentSnapshot doc : documents) {
+            ForumPost post = doc.toObject(ForumPost.class);
+            if (post != null) {
+                post.setId(doc.getId());
+                posts.add(post);
+            }
+        }
+        adapter.setPosts(posts);
+
+        if (isFromCache) {
+            Log.d(TAG, "Forum data loaded from local cache");
+        } else {
+            Log.d(TAG, "Forum data synchronized with server");
+        }
     }
 
     @Override
@@ -305,6 +397,9 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (postsListener != null) {
+            postsListener.remove();
+        }
         binding = null;
     }
 }

--- a/app/src/main/res/layout/fragment_forum.xml
+++ b/app/src/main/res/layout/fragment_forum.xml
@@ -14,6 +14,19 @@
         android:padding="16dp"
         app:layout_constraintTop_toTopOf="parent">
 
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btnFilter"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Filter Posts"
+            android:scaleType="center"
+            android:src="@drawable/ic_filter_list"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorOnSurface" />
+
         <TextView
             android:id="@+id/tvForumTitle"
             android:layout_width="wrap_content"


### PR DESCRIPTION
… to switch between "Recent" and "Following" feeds.

- Added a filter button (`btnFilter`) to `fragment_forum.xml` using `AppCompatImageButton`.
- Integrated `SharedPreferences` to persist the user's selected filter preference across sessions.
- Implemented `listenForFollowingPosts()` to fetch and display posts only from followed users, utilizing Firestore's `whereIn` query.
- Refactored post processing logic into `processSnapshot()` to handle both global and filtered data updates.
- Added a `PopupMenu` to the filter button for toggling between "Recent" and "Following" views.
- Improved resource management by properly detaching the Firestore `ListenerRegistration` in `onDestroyView()`.