### PR TITLE
forum security

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumCommentAdapter.java
+++ b/app/src/main/java/com/birddex/app/ForumCommentAdapter.java
@@ -15,7 +15,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapter.CommentViewHolder> {
@@ -23,12 +25,13 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
     private List<ForumComment> allComments = new ArrayList<>();
     private List<ForumComment> topLevelComments = new ArrayList<>();
     private OnCommentInteractionListener listener;
+    private Set<String> expandedCommentIds = new HashSet<>();
 
     public interface OnCommentInteractionListener {
         void onCommentLikeClick(ForumComment comment);
         void onCommentReplyClick(ForumComment comment);
         void onCommentOptionsClick(ForumComment comment, View view);
-        void onUserClick(String userId); // New method
+        void onUserClick(String userId);
     }
 
     public ForumCommentAdapter(OnCommentInteractionListener listener) {
@@ -56,12 +59,22 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
         List<ForumComment> replies = allComments.stream()
                 .filter(c -> comment.getId().equals(c.getParentCommentId()))
                 .collect(Collectors.toList());
-        holder.bind(comment, replies, listener);
+        
+        boolean isExpanded = expandedCommentIds.contains(comment.getId());
+        holder.bind(comment, replies, isExpanded, listener, (id, expand) -> {
+            if (expand) expandedCommentIds.add(id);
+            else expandedCommentIds.remove(id);
+            notifyItemChanged(position);
+        });
     }
 
     @Override
     public int getItemCount() {
         return topLevelComments.size();
+    }
+
+    interface OnExpandListener {
+        void onExpandToggle(String commentId, boolean expand);
     }
 
     static class CommentViewHolder extends RecyclerView.ViewHolder {
@@ -73,9 +86,11 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
         ImageView ivLikeIcon;
         TextView tvLikeCount;
         TextView btnReply;
+        TextView tvShowReplies;
         RecyclerView rvReplies;
         TextView tvReplyingTo;
         ImageView btnOptions;
+        View llActions;
 
         public CommentViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -87,15 +102,18 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
             ivLikeIcon = itemView.findViewById(R.id.ivCommentLikeIcon);
             tvLikeCount = itemView.findViewById(R.id.tvCommentLikeCount);
             btnReply = itemView.findViewById(R.id.btnReplyComment);
+            tvShowReplies = itemView.findViewById(R.id.tvShowReplies);
             rvReplies = itemView.findViewById(R.id.rvReplies);
             tvReplyingTo = itemView.findViewById(R.id.tvReplyingTo);
             btnOptions = itemView.findViewById(R.id.btnCommentOptions);
+            llActions = itemView.findViewById(R.id.llActions);
         }
 
-        public void bind(ForumComment comment, List<ForumComment> replies, OnCommentInteractionListener listener) {
+        public void bind(ForumComment comment, List<ForumComment> replies, boolean isExpanded, OnCommentInteractionListener listener, OnExpandListener expandListener) {
             tvUsername.setText(comment.getUsername());
             tvText.setText(comment.getText());
             tvLikeCount.setText(String.valueOf(comment.getLikeCount()));
+            llActions.setVisibility(View.VISIBLE);
 
             if (comment.getParentUsername() != null && !comment.getParentUsername().isEmpty()) {
                 tvReplyingTo.setVisibility(View.VISIBLE);
@@ -117,16 +135,36 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
             btnLike.setOnClickListener(v -> listener.onCommentLikeClick(comment));
             btnReply.setOnClickListener(v -> listener.onCommentReplyClick(comment));
             btnOptions.setOnClickListener(v -> listener.onCommentOptionsClick(comment, v));
-            
-            // New click listeners for PFP and Username
             ivUserPfp.setOnClickListener(v -> listener.onUserClick(comment.getUserId()));
             tvUsername.setOnClickListener(v -> listener.onUserClick(comment.getUserId()));
 
             if (replies != null && !replies.isEmpty()) {
-                rvReplies.setVisibility(View.VISIBLE);
-                rvReplies.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
-                rvReplies.setAdapter(new ReplyAdapter(replies, listener));
+                if (isExpanded) {
+                    tvShowReplies.setVisibility(View.VISIBLE);
+                    tvShowReplies.setText("Hide replies");
+                    tvShowReplies.setOnClickListener(v -> expandListener.onExpandToggle(comment.getId(), false));
+                    
+                    rvReplies.setVisibility(View.VISIBLE);
+                    rvReplies.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
+                    rvReplies.setAdapter(new ReplyAdapter(replies, listener));
+                } else {
+                    tvShowReplies.setVisibility(View.VISIBLE);
+                    int remainingCount = replies.size() - 1;
+                    if (remainingCount > 0) {
+                        tvShowReplies.setText("Show " + remainingCount + " more " + (remainingCount == 1 ? "reply" : "replies"));
+                    } else {
+                        tvShowReplies.setVisibility(View.GONE);
+                    }
+                    tvShowReplies.setOnClickListener(v -> expandListener.onExpandToggle(comment.getId(), true));
+                    
+                    rvReplies.setVisibility(View.VISIBLE);
+                    rvReplies.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
+                    List<ForumComment> firstReplyOnly = new ArrayList<>();
+                    firstReplyOnly.add(replies.get(0));
+                    rvReplies.setAdapter(new ReplyAdapter(firstReplyOnly, listener));
+                }
             } else {
+                tvShowReplies.setVisibility(View.GONE);
                 rvReplies.setVisibility(View.GONE);
             }
         }
@@ -165,10 +203,10 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
             TextView tvText;
             LinearLayout btnLike;
             TextView tvLikeCount;
-            TextView btnReply;
             RecyclerView rvReplies;
             TextView tvReplyingTo;
             ImageView btnOptions;
+            View llActions;
 
             ReplyViewHolder(@NonNull View itemView) {
                 super(itemView);
@@ -178,12 +216,13 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                 tvText = itemView.findViewById(R.id.tvCommentText);
                 btnLike = itemView.findViewById(R.id.btnLikeComment);
                 tvLikeCount = itemView.findViewById(R.id.tvCommentLikeCount);
-                btnReply = itemView.findViewById(R.id.btnReplyComment);
                 rvReplies = itemView.findViewById(R.id.rvReplies);
                 tvReplyingTo = itemView.findViewById(R.id.tvReplyingTo);
                 btnOptions = itemView.findViewById(R.id.btnCommentOptions);
+                llActions = itemView.findViewById(R.id.llActions);
                 
-                btnReply.setVisibility(View.GONE);
+                // Replies don't have further nesting or their own reply buttons in this design
+                llActions.setVisibility(View.GONE);
                 rvReplies.setVisibility(View.GONE);
             }
 
@@ -211,8 +250,6 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
 
                 btnLike.setOnClickListener(v -> listener.onCommentLikeClick(reply));
                 btnOptions.setOnClickListener(v -> listener.onCommentOptionsClick(reply, v));
-                
-                // New click listeners for PFP and Username
                 ivUserPfp.setOnClickListener(v -> listener.onUserClick(reply.getUserId()));
                 tvUsername.setOnClickListener(v -> listener.onUserClick(reply.getUserId()));
             }

--- a/app/src/main/java/com/birddex/app/ForumFragment.java
+++ b/app/src/main/java/com/birddex/app/ForumFragment.java
@@ -21,7 +21,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.birddex.app.databinding.FragmentForumBinding;
 import com.bumptech.glide.Glide;
@@ -30,11 +29,15 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.WriteBatch;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * ForumFragment serves as the community hub for users to interact,
@@ -333,18 +336,136 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
     private void showDeleteConfirmation(ForumPost post) {
         new AlertDialog.Builder(requireContext())
                 .setTitle("Delete Post")
-                .setMessage("Are you sure you want to delete this post?")
+                .setMessage("Are you sure you want to delete this post? All comments and images will be archived.")
                 .setPositiveButton("Delete", (dialog, which) -> {
+                    archiveAndDeletePost(post);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void archiveAndDeletePost(ForumPost post) {
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user == null) return;
+
+        String imageUrl = post.getBirdImageUrl();
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            moveImageToArchive(user.getUid(), post.getId(), imageUrl, new OnImageArchivedListener() {
+                @Override
+                public void onSuccess(String archivedUrl) {
+                    post.setBirdImageUrl(archivedUrl);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    Log.e(TAG, "Failed to archive image, proceeding with original URL", e);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post);
+                }
+            });
+        } else {
+            handleCommentsArchiveAndDeletion(user.getUid(), post);
+        }
+    }
+
+    private void handleCommentsArchiveAndDeletion(String userId, ForumPost post) {
+        // Fetch all comments to archive them before deleting the post
+        db.collection("forumThreads").document(post.getId()).collection("comments")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    WriteBatch batch = db.batch();
+                    
+                    // Archive and delete each comment
+                    for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                        Map<String, Object> commentBacklog = new HashMap<>();
+                        commentBacklog.put("type", "comment_archived_with_post");
+                        commentBacklog.put("originalId", doc.getId());
+                        commentBacklog.put("postId", post.getId());
+                        commentBacklog.put("data", doc.getData());
+                        commentBacklog.put("deletedBy", userId);
+                        commentBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                        
+                        batch.set(db.collection("deleted_backlog").document(), commentBacklog);
+                        batch.delete(doc.getReference());
+                    }
+                    
+                    // Final post archive
+                    Map<String, Object> postBacklog = new HashMap<>();
+                    postBacklog.put("type", "post");
+                    postBacklog.put("originalId", post.getId());
+                    postBacklog.put("data", post);
+                    postBacklog.put("deletedBy", userId);
+                    postBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                    
+                    batch.set(db.collection("deleted_backlog").document(), postBacklog);
+                    
+                    // Delete the post document itself
+                    batch.delete(db.collection("forumThreads").document(post.getId()));
+                    
+                    batch.commit().addOnSuccessListener(aVoid -> {
+                        if (!isAdded()) return;
+                        Toast.makeText(getContext(), "Post and comments deleted", Toast.LENGTH_SHORT).show();
+                        refreshPosts();
+                    }).addOnFailureListener(e -> {
+                        Log.e(TAG, "Failed to execute deletion batch", e);
+                        Toast.makeText(getContext(), "Error deleting post content", Toast.LENGTH_SHORT).show();
+                    });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to fetch comments for deletion", e);
+                    // Fallback: just delete the post
+                    savePostToBacklogAndFirestore(userId, post);
+                });
+    }
+
+    private interface OnImageArchivedListener {
+        void onSuccess(String archivedUrl);
+        void onFailure(Exception e);
+    }
+
+    private void moveImageToArchive(String userId, String postId, String originalUrl, OnImageArchivedListener listener) {
+        FirebaseStorage storage = FirebaseStorage.getInstance();
+        try {
+            StorageReference oldRef = storage.getReferenceFromUrl(originalUrl);
+            String fileName = oldRef.getName();
+            StorageReference newRef = storage.getReference().child("archive/forum_post_images/" + userId + "/" + postId + "_" + fileName);
+
+            oldRef.getBytes(10 * 1024 * 1024).addOnSuccessListener(bytes -> {
+                newRef.putBytes(bytes).addOnSuccessListener(taskSnapshot -> {
+                    newRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                        oldRef.delete().addOnCompleteListener(task -> {
+                            listener.onSuccess(uri.toString());
+                        });
+                    }).addOnFailureListener(listener::onFailure);
+                }).addOnFailureListener(listener::onFailure);
+            }).addOnFailureListener(listener::onFailure);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void savePostToBacklogAndFirestore(String userId, ForumPost post) {
+        Map<String, Object> backlogData = new HashMap<>();
+        backlogData.put("type", "post");
+        backlogData.put("originalId", post.getId());
+        backlogData.put("data", post);
+        backlogData.put("deletedBy", userId);
+        backlogData.put("deletedAt", FieldValue.serverTimestamp());
+
+        db.collection("deleted_backlog").add(backlogData)
+                .addOnSuccessListener(docRef -> {
                     firebaseManager.deleteForumPost(post.getId(), task -> {
                         if (!isAdded()) return;
                         if (task.isSuccessful()) {
                             Toast.makeText(getContext(), "Post deleted", Toast.LENGTH_SHORT).show();
-                            refreshPosts(); // Refresh after deletion
+                            refreshPosts();
                         }
                     });
                 })
-                .setNegativeButton("Cancel", null)
-                .show();
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to backlog post", e);
+                    Toast.makeText(getContext(), "Failed to delete post. Try again.", Toast.LENGTH_SHORT).show();
+                });
     }
 
     private void showReportDialog(ForumPost post) {

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -48,13 +48,16 @@ import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.Source;
+import com.google.firebase.firestore.WriteBatch;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 import com.google.maps.android.heatmaps.Gradient;
 import com.google.maps.android.heatmaps.HeatmapTileProvider;
 import com.google.maps.android.heatmaps.WeightedLatLng;
@@ -110,6 +113,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
     private GoogleMap googleMap;
     private FirebaseFirestore db;
+    private FirebaseAuth mAuth;
     private TextView tvMapSubtitle;
 
     private TileOverlay userOverlay;
@@ -133,6 +137,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     private EditText currentPopupEditText;
     private ForumPost activePost;
     private FirebaseManager firebaseManager;
+    private ForumCommentAdapter popupCommentAdapter;
 
     // Pagination for popup comments
     private List<ForumComment> popupCommentList = new ArrayList<>();
@@ -147,6 +152,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         setContentView(R.layout.activity_nearby_heatmap);
 
         db = FirebaseFirestore.getInstance();
+        mAuth = FirebaseAuth.getInstance();
         firebaseManager = new FirebaseManager(this);
 
         ImageButton btnBack = findViewById(R.id.btnBack);
@@ -392,19 +398,19 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             dialog.dismiss();
         });
 
-        btnPostOptions.setOnClickListener(v -> showPostOptions(post, v));
+        btnPostOptions.setOnClickListener(v -> showPostOptions(post, v, dialog));
 
         // Setup Comments with Pagination
         RecyclerView rvComments = view.findViewById(R.id.rvComments);
-        ForumCommentAdapter adapter = new ForumCommentAdapter(this);
+        popupCommentAdapter = new ForumCommentAdapter(this);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         rvComments.setLayoutManager(layoutManager);
-        rvComments.setAdapter(adapter);
+        rvComments.setAdapter(popupCommentAdapter);
 
         popupCommentList.clear();
         lastPopupCommentVisible = null;
         isLastPopupCommentsPage = false;
-        fetchPopupComments(post.getId(), adapter);
+        fetchPopupComments(post.getId(), popupCommentAdapter);
 
         rvComments.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
@@ -416,7 +422,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
                     if (!isFetchingPopupComments && !isLastPopupCommentsPage) {
                         if ((visibleItemCount + pastVisibleItems) >= totalItemCount) {
-                            fetchPopupComments(post.getId(), adapter);
+                            fetchPopupComments(post.getId(), popupCommentAdapter);
                         }
                     }
                 }
@@ -451,19 +457,20 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                     comment.setParentCommentId(replyingToComment.getId());
                     comment.setParentUsername(replyingToComment.getUsername());
                 }
-                db.collection("forumThreads").document(post.getId()).collection("comments").add(comment)
-                        .addOnSuccessListener(ref -> {
-                            currentPopupEditText.setText("");
-                            currentPopupEditText.setHint("Write a comment...");
-                            replyingToComment = null;
-                            db.collection("forumThreads").document(post.getId()).update("commentCount", FieldValue.increment(1));
-                            
-                            // Simple refresh
-                            popupCommentList.clear();
-                            lastPopupCommentVisible = null;
-                            isLastPopupCommentsPage = false;
-                            fetchPopupComments(post.getId(), adapter);
-                        });
+                
+                WriteBatch batch = db.batch();
+                DocumentReference commentRef = db.collection("forumThreads").document(post.getId()).collection("comments").document();
+                batch.set(commentRef, comment);
+                batch.update(db.collection("forumThreads").document(post.getId()), "commentCount", FieldValue.increment(1));
+                
+                batch.commit().addOnSuccessListener(aVoid -> {
+                    currentPopupEditText.setText("");
+                    currentPopupEditText.setHint("Write a comment...");
+                    replyingToComment = null;
+                    
+                    // Simple refresh
+                    refreshPopupComments();
+                });
             });
         });
 
@@ -475,6 +482,14 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
             behavior.setSkipCollapsed(true);
         }
+    }
+
+    private void refreshPopupComments() {
+        if (activePost == null || popupCommentAdapter == null) return;
+        popupCommentList.clear();
+        lastPopupCommentVisible = null;
+        isLastPopupCommentsPage = false;
+        fetchPopupComments(activePost.getId(), popupCommentAdapter);
     }
 
     private void fetchPopupComments(String postId, ForumCommentAdapter adapter) {
@@ -510,7 +525,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         });
     }
 
-    private void showPostOptions(ForumPost post, View view) {
+    private void showPostOptions(ForumPost post, View view, BottomSheetDialog dialog) {
         PopupMenu popup = new PopupMenu(this, view);
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         
@@ -521,7 +536,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) {
-                showDeleteConfirmation(post);
+                showDeleteConfirmation(post, dialog);
             } else if (item.getTitle().equals("Report")) {
                 showReportDialog("post", post.getId());
             }
@@ -530,20 +545,133 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         popup.show();
     }
 
-    private void showDeleteConfirmation(ForumPost post) {
+    private void showDeleteConfirmation(ForumPost post, BottomSheetDialog bottomSheetDialog) {
         new AlertDialog.Builder(this)
                 .setTitle("Delete Post")
-                .setMessage("Are you sure you want to delete this post?")
+                .setMessage("Are you sure you want to delete this post? All comments and images will be archived.")
                 .setPositiveButton("Delete", (dialog, which) -> {
-                    firebaseManager.deleteForumPost(post.getId(), task -> {
-                        if (task.isSuccessful()) {
-                            Toast.makeText(this, "Post deleted", Toast.LENGTH_SHORT).show();
-                            loadForumPins(); // Refresh
-                        }
-                    });
+                    archiveAndDeletePost(post, bottomSheetDialog);
                 })
                 .setNegativeButton("Cancel", null)
                 .show();
+    }
+
+    private void archiveAndDeletePost(ForumPost post, BottomSheetDialog bottomSheetDialog) {
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user == null) return;
+
+        String imageUrl = post.getBirdImageUrl();
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            moveImageToArchive(user.getUid(), post.getId(), imageUrl, new OnImageArchivedListener() {
+                @Override
+                public void onSuccess(String archivedUrl) {
+                    post.setBirdImageUrl(archivedUrl);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post, bottomSheetDialog);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    Log.e(TAG, "Failed to archive image, proceeding with original URL", e);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post, bottomSheetDialog);
+                }
+            });
+        } else {
+            handleCommentsArchiveAndDeletion(user.getUid(), post, bottomSheetDialog);
+        }
+    }
+
+    private void handleCommentsArchiveAndDeletion(String userId, ForumPost post, BottomSheetDialog bottomSheetDialog) {
+        db.collection("forumThreads").document(post.getId()).collection("comments")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    WriteBatch batch = db.batch();
+                    
+                    for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                        Map<String, Object> commentBacklog = new HashMap<>();
+                        commentBacklog.put("type", "comment_archived_with_post");
+                        commentBacklog.put("originalId", doc.getId());
+                        commentBacklog.put("postId", post.getId());
+                        commentBacklog.put("data", doc.getData());
+                        commentBacklog.put("deletedBy", userId);
+                        commentBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                        
+                        batch.set(db.collection("deleted_backlog").document(), commentBacklog);
+                        batch.delete(doc.getReference());
+                    }
+                    
+                    Map<String, Object> postBacklog = new HashMap<>();
+                    postBacklog.put("type", "post");
+                    postBacklog.put("originalId", post.getId());
+                    postBacklog.put("data", post);
+                    postBacklog.put("deletedBy", userId);
+                    postBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                    
+                    batch.set(db.collection("deleted_backlog").document(), postBacklog);
+                    batch.delete(db.collection("forumThreads").document(post.getId()));
+                    
+                    batch.commit().addOnSuccessListener(aVoid -> {
+                        Toast.makeText(this, "Post and comments deleted", Toast.LENGTH_SHORT).show();
+                        if (bottomSheetDialog != null) bottomSheetDialog.dismiss();
+                        loadForumPins();
+                    }).addOnFailureListener(e -> {
+                        Log.e(TAG, "Failed to execute deletion batch", e);
+                        Toast.makeText(this, "Error deleting post content", Toast.LENGTH_SHORT).show();
+                    });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to fetch comments for deletion", e);
+                    savePostToBacklogAndFirestore(userId, post, bottomSheetDialog);
+                });
+    }
+
+    private interface OnImageArchivedListener {
+        void onSuccess(String archivedUrl);
+        void onFailure(Exception e);
+    }
+
+    private void moveImageToArchive(String userId, String postId, String originalUrl, OnImageArchivedListener listener) {
+        FirebaseStorage storage = FirebaseStorage.getInstance();
+        try {
+            StorageReference oldRef = storage.getReferenceFromUrl(originalUrl);
+            String fileName = oldRef.getName();
+            StorageReference newRef = storage.getReference().child("archive/forum_post_images/" + userId + "/" + postId + "_" + fileName);
+
+            oldRef.getBytes(10 * 1024 * 1024).addOnSuccessListener(bytes -> {
+                newRef.putBytes(bytes).addOnSuccessListener(taskSnapshot -> {
+                    newRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                        oldRef.delete().addOnCompleteListener(task -> {
+                            listener.onSuccess(uri.toString());
+                        });
+                    }).addOnFailureListener(listener::onFailure);
+                }).addOnFailureListener(listener::onFailure);
+            }).addOnFailureListener(listener::onFailure);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void savePostToBacklogAndFirestore(String userId, ForumPost post, BottomSheetDialog bottomSheetDialog) {
+        Map<String, Object> backlogData = new HashMap<>();
+        backlogData.put("type", "post");
+        backlogData.put("originalId", post.getId());
+        backlogData.put("data", post);
+        backlogData.put("deletedBy", userId);
+        backlogData.put("deletedAt", FieldValue.serverTimestamp());
+
+        db.collection("deleted_backlog").add(backlogData)
+                .addOnSuccessListener(docRef -> {
+                    firebaseManager.deleteForumPost(post.getId(), task -> {
+                        if (task.isSuccessful()) {
+                            Toast.makeText(this, "Post deleted", Toast.LENGTH_SHORT).show();
+                            if (bottomSheetDialog != null) bottomSheetDialog.dismiss();
+                            loadForumPins();
+                        }
+                    });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to backlog post", e);
+                    Toast.makeText(this, "Failed to delete post. Try again.", Toast.LENGTH_SHORT).show();
+                });
     }
 
     private void showReportDialog(String type, String targetId) {
@@ -584,8 +712,6 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
         input.setHint("Please specify the reason (max 200 chars)...");
         input.setFilters(new InputFilter[]{new InputFilter.LengthFilter(200)});
-        input.setSingleLine(false);
-        input.setHorizontallyScrolling(false);
         input.setLines(5);
 
         FrameLayout container = new FrameLayout(this);
@@ -650,26 +776,94 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         
         boolean isCommentAuthor = user != null && comment.getUserId().equals(user.getUid());
-        boolean isPostAuthor = user != null && activePost != null && activePost.getUserId().equals(user.getUid());
 
-        if (isCommentAuthor || isPostAuthor) {
+        if (isCommentAuthor) {
             popup.getMenu().add("Delete");
         }
         popup.getMenu().add("Report");
 
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) {
-                db.collection("forumThreads").document(activePost.getId()).collection("comments").document(comment.getId())
-                        .delete().addOnSuccessListener(aVoid -> {
-                            Toast.makeText(this, "Comment deleted", Toast.LENGTH_SHORT).show();
-                            db.collection("forumThreads").document(activePost.getId()).update("commentCount", FieldValue.increment(-1));
-                        });
+                showCommentDeleteConfirmation(comment);
             } else if (item.getTitle().equals("Report")) {
                 showReportDialog("comment", comment.getId());
             }
             return true;
         });
         popup.show();
+    }
+
+    private void showCommentDeleteConfirmation(ForumComment comment) {
+        new AlertDialog.Builder(this)
+                .setTitle("Delete Comment")
+                .setMessage("Are you sure you want to delete this comment? " + (comment.getParentCommentId() == null ? "All replies will also be deleted." : ""))
+                .setPositiveButton("Delete", (dialog, which) -> {
+                    deleteCommentAndReplies(comment);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void deleteCommentAndReplies(ForumComment comment) {
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user == null || activePost == null) return;
+
+        if (comment.getParentCommentId() == null) {
+            db.collection("forumThreads").document(activePost.getId()).collection("comments")
+                    .whereEqualTo("parentCommentId", comment.getId())
+                    .get()
+                    .addOnSuccessListener(queryDocumentSnapshots -> {
+                        WriteBatch batch = db.batch();
+                        int totalToDelete = queryDocumentSnapshots.size() + 1;
+
+                        for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                            backlogByUserId(batch, user.getUid(), "comment_reply", doc.getId(), doc.getData());
+                            batch.delete(doc.getReference());
+                        }
+                        
+                        backlogByUserId(batch, user.getUid(), "comment", comment.getId(), comment);
+
+                        batch.delete(db.collection("forumThreads").document(activePost.getId())
+                                .collection("comments").document(comment.getId()));
+                        
+                        batch.update(db.collection("forumThreads").document(activePost.getId()), 
+                                "commentCount", FieldValue.increment(-totalToDelete));
+                        
+                        batch.commit().addOnSuccessListener(aVoid -> {
+                            Toast.makeText(this, "Comment deleted", Toast.LENGTH_SHORT).show();
+                            refreshPopupComments();
+                        });
+                    });
+        } else {
+            Map<String, Object> replyBacklog = new HashMap<>();
+            replyBacklog.put("type", "reply");
+            replyBacklog.put("originalId", comment.getId());
+            replyBacklog.put("data", comment);
+            replyBacklog.put("deletedBy", user.getUid());
+            replyBacklog.put("deletedAt", FieldValue.serverTimestamp());
+
+            db.collection("deleted_backlog").add(replyBacklog)
+                    .addOnSuccessListener(docRef -> {
+                        firebaseManager.deleteForumComment(activePost.getId(), comment.getId(), task -> {
+                            if (task.isSuccessful()) {
+                                Toast.makeText(this, "Reply deleted", Toast.LENGTH_SHORT).show();
+                                db.collection("forumThreads").document(activePost.getId())
+                                        .update("commentCount", FieldValue.increment(-1));
+                                refreshPopupComments();
+                            }
+                        });
+                    });
+        }
+    }
+
+    private void backlogByUserId(WriteBatch batch, String uid, String type, String originalId, Object data) {
+        Map<String, Object> backlog = new HashMap<>();
+        backlog.put("type", type);
+        backlog.put("originalId", originalId);
+        backlog.put("data", data);
+        backlog.put("deletedBy", uid);
+        backlog.put("deletedAt", FieldValue.serverTimestamp());
+        batch.set(db.collection("deleted_backlog").document(), backlog);
     }
 
     @Override

--- a/app/src/main/java/com/birddex/app/PostDetailActivity.java
+++ b/app/src/main/java/com/birddex/app/PostDetailActivity.java
@@ -29,12 +29,15 @@ import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.WriteBatch;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,6 +67,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
     private boolean isLastCommentsPage = false;
     
     private ForumComment replyingToComment = null;
+    private boolean hasMarkedAsViewed = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -122,35 +126,37 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
                             originalPost.setId(doc.getId());
 
                             FirebaseUser user = mAuth.getCurrentUser();
-                            if (user != null) {
+                            if (user != null && !hasMarkedAsViewed && !doc.getMetadata().hasPendingWrites()) {
                                 String userId = user.getUid();
-                                if (!doc.getMetadata().isFromCache()) {
-                                    if (originalPost.getViewedBy() == null || !originalPost.getViewedBy().containsKey(userId)) {
-                                        db.collection("forumThreads").document(postId)
-                                                .update("viewCount", FieldValue.increment(1),
-                                                        "viewedBy." + userId, true);
-                                    }
-
-                                    if (userId.equals(originalPost.getUserId())) {
-                                        Map<String, Object> updates = new HashMap<>();
-                                        if (originalPost.isNotificationSent()) {
-                                            updates.put("notificationSent", false);
-                                        }
-                                        if (originalPost.isLikeNotificationSent()) {
-                                            updates.put("likeNotificationSent", false);
-                                        }
-                                        updates.put("lastViewedAt", FieldValue.serverTimestamp());
-                                        
-                                        if (!updates.isEmpty()) {
-                                            db.collection("forumThreads").document(postId).update(updates);
-                                        }
-                                    }
-                                }
+                                handleViewTracking(userId, originalPost);
                             }
+                            
                             bindPostToLayout(originalPost);
                         }
                     }
                 });
+    }
+
+    private void handleViewTracking(String userId, ForumPost post) {
+        hasMarkedAsViewed = true; // Prevent loop
+        Map<String, Object> updates = new HashMap<>();
+
+        // Increment view count if user hasn't seen it yet
+        if (post.getViewedBy() == null || !post.getViewedBy().containsKey(userId)) {
+            updates.put("viewCount", FieldValue.increment(1));
+            updates.put("viewedBy." + userId, true);
+        }
+
+        // Clear notifications for the owner
+        if (userId.equals(post.getUserId())) {
+            if (post.isNotificationSent()) updates.put("notificationSent", false);
+            if (post.isLikeNotificationSent()) updates.put("likeNotificationSent", false);
+            updates.put("lastViewedAt", FieldValue.serverTimestamp());
+        }
+
+        if (!updates.isEmpty()) {
+            db.collection("forumThreads").document(postId).update(updates);
+        }
     }
 
     private void bindPostToLayout(ForumPost post) {
@@ -287,7 +293,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
     private void showDeleteConfirmation(ForumPost post) {
         new AlertDialog.Builder(this)
                 .setTitle("Delete Post")
-                .setMessage("Are you sure you want to delete this post?")
+                .setMessage("Are you sure you want to delete this post? All comments and images will be archived.")
                 .setPositiveButton("Delete", (dialog, which) -> {
                     archiveAndDeletePost(post);
                 })
@@ -299,11 +305,102 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
         FirebaseUser user = mAuth.getCurrentUser();
         if (user == null) return;
 
+        String imageUrl = post.getBirdImageUrl();
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            moveImageToArchive(user.getUid(), post.getId(), imageUrl, new OnImageArchivedListener() {
+                @Override
+                public void onSuccess(String archivedUrl) {
+                    post.setBirdImageUrl(archivedUrl);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    Log.e(TAG, "Failed to archive image, proceeding with original URL", e);
+                    handleCommentsArchiveAndDeletion(user.getUid(), post);
+                }
+            });
+        } else {
+            handleCommentsArchiveAndDeletion(user.getUid(), post);
+        }
+    }
+
+    private void handleCommentsArchiveAndDeletion(String userId, ForumPost post) {
+        db.collection("forumThreads").document(post.getId()).collection("comments")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    WriteBatch batch = db.batch();
+                    
+                    for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                        Map<String, Object> commentBacklog = new HashMap<>();
+                        commentBacklog.put("type", "comment_archived_with_post");
+                        commentBacklog.put("originalId", doc.getId());
+                        commentBacklog.put("postId", post.getId());
+                        commentBacklog.put("data", doc.getData());
+                        commentBacklog.put("deletedBy", userId);
+                        commentBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                        
+                        batch.set(db.collection("deleted_backlog").document(), commentBacklog);
+                        batch.delete(doc.getReference());
+                    }
+                    
+                    Map<String, Object> postBacklog = new HashMap<>();
+                    postBacklog.put("type", "post");
+                    postBacklog.put("originalId", post.getId());
+                    postBacklog.put("data", post);
+                    postBacklog.put("deletedBy", userId);
+                    postBacklog.put("deletedAt", FieldValue.serverTimestamp());
+                    
+                    batch.set(db.collection("deleted_backlog").document(), postBacklog);
+                    batch.delete(db.collection("forumThreads").document(post.getId()));
+                    
+                    batch.commit().addOnSuccessListener(aVoid -> {
+                        if (isFinishing() || isDestroyed()) return;
+                        Toast.makeText(this, "Post and comments deleted", Toast.LENGTH_SHORT).show();
+                        finish();
+                    }).addOnFailureListener(e -> {
+                        Log.e(TAG, "Failed to execute deletion batch", e);
+                        Toast.makeText(this, "Error deleting post content", Toast.LENGTH_SHORT).show();
+                    });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to fetch comments for deletion", e);
+                    savePostToBacklogAndFirestore(userId, post);
+                });
+    }
+
+    private interface OnImageArchivedListener {
+        void onSuccess(String archivedUrl);
+        void onFailure(Exception e);
+    }
+
+    private void moveImageToArchive(String userId, String postId, String originalUrl, OnImageArchivedListener listener) {
+        FirebaseStorage storage = FirebaseStorage.getInstance();
+        try {
+            StorageReference oldRef = storage.getReferenceFromUrl(originalUrl);
+            String fileName = oldRef.getName();
+            StorageReference newRef = storage.getReference().child("archive/forum_post_images/" + userId + "/" + postId + "_" + fileName);
+
+            oldRef.getBytes(10 * 1024 * 1024).addOnSuccessListener(bytes -> {
+                newRef.putBytes(bytes).addOnSuccessListener(taskSnapshot -> {
+                    newRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                        oldRef.delete().addOnCompleteListener(task -> {
+                            listener.onSuccess(uri.toString());
+                        });
+                    }).addOnFailureListener(listener::onFailure);
+                }).addOnFailureListener(listener::onFailure);
+            }).addOnFailureListener(listener::onFailure);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void savePostToBacklogAndFirestore(String userId, ForumPost post) {
         Map<String, Object> backlogData = new HashMap<>();
         backlogData.put("type", "post");
         backlogData.put("originalId", post.getId());
         backlogData.put("data", post);
-        backlogData.put("deletedBy", user.getUid());
+        backlogData.put("deletedBy", userId);
         backlogData.put("deletedAt", FieldValue.serverTimestamp());
 
         db.collection("deleted_backlog").add(backlogData)
@@ -317,7 +414,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
                     });
                 })
                 .addOnFailureListener(e -> {
-                    Log.e(TAG, "Failed to backlog post before deletion", e);
+                    Log.e(TAG, "Failed to backlog post", e);
                     Toast.makeText(this, "Failed to delete post. Try again.", Toast.LENGTH_SHORT).show();
                 });
     }
@@ -449,17 +546,20 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
             comment.setParentUsername(replyingToComment.getUsername());
         }
         
-        db.collection("forumThreads").document(postId).collection("comments").add(comment)
-                .addOnSuccessListener(docRef -> {
+        WriteBatch batch = db.batch();
+        DocumentReference commentRef = db.collection("forumThreads").document(postId).collection("comments").document();
+        batch.set(commentRef, comment);
+        batch.update(db.collection("forumThreads").document(postId), "commentCount", FieldValue.increment(1));
+        
+        batch.commit()
+                .addOnSuccessListener(aVoid -> {
                     if (isFinishing() || isDestroyed()) return;
                     binding.etComment.setText("");
                     binding.etComment.setHint("Write a comment...");
                     replyingToComment = null;
                     binding.btnSendComment.setEnabled(true);
-                    db.collection("forumThreads").document(postId)
-                            .update("commentCount", FieldValue.increment(1));
                     
-                    // Simple logic to show the new comment: refresh list
+                    // Refresh list
                     lastCommentVisible = null;
                     isLastCommentsPage = false;
                     commentList.clear();
@@ -513,7 +613,6 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
         FirebaseUser user = mAuth.getCurrentUser();
         
         boolean isCommentAuthor = user != null && comment.getUserId().equals(user.getUid());
-        boolean isPostAuthor = user != null && originalPost != null && originalPost.getUserId().equals(user.getUid());
 
         if (isCommentAuthor) {
             if (comment.getTimestamp() != null) {
@@ -522,9 +621,6 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
                     popup.getMenu().add("Edit");
                 }
             }
-        }
-
-        if (isCommentAuthor || isPostAuthor) {
             popup.getMenu().add("Delete");
         }
         popup.getMenu().add("Report");

--- a/app/src/main/res/layout/item_forum_comment.xml
+++ b/app/src/main/res/layout/item_forum_comment.xml
@@ -110,10 +110,12 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/llActions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
         android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
 
         <TextView
@@ -125,6 +127,18 @@
             android:textSize="12sp"
             android:textStyle="bold"
             android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <TextView
+            android:id="@+id/tvShowReplies"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:padding="4dp"
+            android:text="Show 2 more replies"
+            android:textSize="12sp"
+            android:textColor="?attr/colorPrimary"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
     </LinearLayout>
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -106,17 +106,33 @@ service cloud.firestore {
         allow write: if request.auth != null && request.auth.uid == resource.data.userId;
     }
 
-    // NEW FORUM RULES
+    // UPDATED FORUM RULES
     match /forumThreads/{threadId} {
         allow read: if request.auth != null;
         allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
-        allow update: if request.auth != null; // Allow updates for likes and view counts
+
+        // Owner can update everything; others can only update likes/views/counts
+        allow update: if request.auth != null && (
+            (request.auth.uid == resource.data.userId) ||
+            (request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+                'likeCount', 'likedBy', 'viewCount', 'viewedBy', 'commentCount',
+                'lastViewedAt', 'notificationSent', 'likeNotificationSent'
+            ]))
+        );
+
         allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
 
         match /comments/{commentId} {
             allow read: if request.auth != null;
             allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
-            allow update: if request.auth != null; // Allow updates for comment likes
+
+            // Owner can update text; others can only update likes
+            allow update: if request.auth != null && (
+                (request.auth.uid == resource.data.userId) ||
+                (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likeCount', 'likedBy']))
+            );
+
+            // Only the comment author can delete (Post owner is NOT included)
             allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
         }
     }
@@ -125,6 +141,12 @@ service cloud.firestore {
     match /reports/{reportId} {
         allow create: if request.auth != null;
         allow read, update, delete: if false;
+    }
+
+    // Allow users to archive their deleted content
+    match /deleted_backlog/{docId} {
+        allow create: if request.auth != null && request.resource.data.deletedBy == request.auth.uid;
+        allow read, update, delete: if false; // Only accessible via Firebase Console/Admin SDK
     }
 
     // eBird cache is read-only for clients (written by Cloud Function).

--- a/storage.rules
+++ b/storage.rules
@@ -27,6 +27,15 @@ service firebase.storage {
     match /forum_post_images/{imageId} {
       allow read: if request.auth != null;
       allow write: if request.auth != null;
+      // Allow deletion only if the user is authenticated (handled by app logic with backlog)
+      allow delete: if request.auth != null;
+    }
+
+    // Rule for ARCHIVED forum post images
+    match /archive/forum_post_images/{userId}/{imageId} {
+      // Only admins should ideally read this, but for app logic we allow write/create
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
     // Rule for ebird_birds_export


### PR DESCRIPTION
Implemented enhanced forum data retention and moderation features.

- **Data Archiving & Deletion**: Added a `deleted_backlog` collection in Firestore and an `archive/` path in Cloud Storage to store deleted posts, comments, and images for administrative review. Post deletion now performs a batch operation to archive all associated comments and move images before document removal.
 

- **Improved Commenting**: Refined the `ForumCommentAdapter` to support collapsible reply threads ("Show/Hide replies") and ensured comment deletion correctly handles nested replies.


- **Enhanced Security & Rules**: Updated Firestore and Storage rules to allow users to create entries in the deletion backlog and restrict update permissions to specific fields (e.g., like/view counts) for non-owners.


- **Bug Fixes & UI**: Fixed a potential view-tracking loop in `PostDetailActivity` and synchronized comment count updates across `NearbyHeatmapActivity` and `PostDetailActivity` using Firestore batches. Modified `item_forum_comment.xml` to include a "Show replies" toggle.
