### PR TITLE
Implemented a 24-hour cooldown for user bird sightings on the heatmap…

### DIFF
--- a/app/src/main/java/com/birddex/app/BirdInfoActivity.java
+++ b/app/src/main/java/com/birddex/app/BirdInfoActivity.java
@@ -3,35 +3,16 @@ package com.birddex.app;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.View;
 import android.widget.Button;
-import android.widget.CheckBox;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseUser;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.Query;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 public class BirdInfoActivity extends AppCompatActivity {
-
-    private static final String TAG = "BirdInfoActivity";
-    private FirebaseManager firebaseManager;
 
     private String currentImageUriStr;
     private String currentBirdId;
@@ -40,15 +21,12 @@ public class BirdInfoActivity extends AppCompatActivity {
     private String currentSpecies;
     private String currentFamily;
 
-    private String currentImageUrl; // Firebase Storage URL (identificationImages)
-    private Double currentLatitude; // nullable
-    private Double currentLongitude; // nullable
+    private Double currentLatitude;
+    private Double currentLongitude;
     private String currentLocalityName;
     private String currentState;
     private String currentCountry;
 
-    private CheckBox cbYes, cbNo;
-    private LinearLayout layoutQuantity;
     private RadioGroup rgQuantity;
     private Button btnStore;
 
@@ -64,13 +42,7 @@ public class BirdInfoActivity extends AppCompatActivity {
         TextView familyTextView = findViewById(R.id.familyTextView);
         btnStore = findViewById(R.id.btnStore);
         Button btnDiscard = findViewById(R.id.btnDiscard);
-
-        cbYes = findViewById(R.id.cbYes);
-        cbNo = findViewById(R.id.cbNo);
-        layoutQuantity = findViewById(R.id.layoutQuantity);
         rgQuantity = findViewById(R.id.rgQuantity);
-
-        firebaseManager = new FirebaseManager(this);
 
         currentImageUriStr = getIntent().getStringExtra("imageUri");
         currentBirdId = getIntent().getStringExtra("birdId");
@@ -79,8 +51,6 @@ public class BirdInfoActivity extends AppCompatActivity {
         currentSpecies = getIntent().getStringExtra("species");
         currentFamily = getIntent().getStringExtra("family");
 
-        // From the identification phase
-        currentImageUrl = getIntent().getStringExtra("imageUrl");
         currentLatitude = getIntent().hasExtra("latitude") ? getIntent().getDoubleExtra("latitude", 0.0) : null;
         currentLongitude = getIntent().hasExtra("longitude") ? getIntent().getDoubleExtra("longitude", 0.0) : null;
         currentLocalityName = getIntent().getStringExtra("localityName");
@@ -96,33 +66,13 @@ public class BirdInfoActivity extends AppCompatActivity {
         speciesTextView.setText("Species: " + (currentSpecies != null ? currentSpecies : "N/A"));
         familyTextView.setText("Family: " + (currentFamily != null ? currentFamily : "N/A"));
 
-        // Logic for CheckBoxes
-        cbYes.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            if (isChecked) {
-                cbNo.setChecked(false);
-                layoutQuantity.setVisibility(View.VISIBLE);
-            } else {
-                layoutQuantity.setVisibility(View.GONE);
-                rgQuantity.clearCheck();
-            }
-            updateStoreButtonState();
-        });
+        rgQuantity.setOnCheckedChangeListener((group, checkedId) ->
+                btnStore.setEnabled(checkedId != -1)
+        );
 
-        cbNo.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            if (isChecked) {
-                cbYes.setChecked(false);
-                layoutQuantity.setVisibility(View.GONE);
-                rgQuantity.clearCheck();
-            }
-            updateStoreButtonState();
-        });
-
-        rgQuantity.setOnCheckedChangeListener((group, checkedId) -> updateStoreButtonState());
-
-        // Store: Pass data to CardMakerActivity for permanent storage
         btnStore.setOnClickListener(v -> {
             String quantity = getSelectedQuantity();
-            
+
             long caughtTime = System.currentTimeMillis();
             Intent i = new Intent(BirdInfoActivity.this, CardMakerActivity.class);
             i.putExtra(CardMakerActivity.EXTRA_IMAGE_URI, currentImageUriStr);
@@ -131,18 +81,16 @@ public class BirdInfoActivity extends AppCompatActivity {
             i.putExtra(CardMakerActivity.EXTRA_CAUGHT_TIME, caughtTime);
             i.putExtra(CardMakerActivity.EXTRA_BIRD_NAME, currentCommonName);
             i.putExtra(CardMakerActivity.EXTRA_SCI_NAME, currentScientificName);
-            i.putExtra(CardMakerActivity.EXTRA_CONFIDENCE, "--"); 
-            i.putExtra(CardMakerActivity.EXTRA_RARITY, "Unknown"); 
+            i.putExtra(CardMakerActivity.EXTRA_CONFIDENCE, "--");
+            i.putExtra(CardMakerActivity.EXTRA_RARITY, "Unknown");
             i.putExtra(CardMakerActivity.EXTRA_BIRD_ID, currentBirdId);
             i.putExtra(CardMakerActivity.EXTRA_SPECIES, currentSpecies);
             i.putExtra(CardMakerActivity.EXTRA_FAMILY, currentFamily);
-            
-            // Pass the crucial extras for Sighting and Collection
-            i.putExtra("quantity", quantity);
-            i.putExtra("recordSighting", cbYes.isChecked());
-            if (currentLatitude != null) i.putExtra("latitude", currentLatitude);
-            if (currentLongitude != null) i.putExtra("longitude", currentLongitude);
-            i.putExtra("country", currentCountry);
+            i.putExtra(CardMakerActivity.EXTRA_QUANTITY, quantity);
+            i.putExtra(CardMakerActivity.EXTRA_RECORD_SIGHTING, true);
+            if (currentLatitude != null) i.putExtra(CardMakerActivity.EXTRA_LATITUDE, currentLatitude);
+            if (currentLongitude != null) i.putExtra(CardMakerActivity.EXTRA_LONGITUDE, currentLongitude);
+            i.putExtra(CardMakerActivity.EXTRA_COUNTRY, currentCountry);
 
             startActivity(i);
         });
@@ -155,32 +103,12 @@ public class BirdInfoActivity extends AppCompatActivity {
         });
     }
 
-    private void updateStoreButtonState() {
-        boolean isYesChecked = cbYes.isChecked();
-        boolean isNoChecked = cbNo.isChecked();
-        boolean isQuantitySelected = rgQuantity.getCheckedRadioButtonId() != -1;
-
-        if (isNoChecked) {
-            btnStore.setEnabled(true);
-        } else if (isYesChecked && isQuantitySelected) {
-            btnStore.setEnabled(true);
-        } else {
-            btnStore.setEnabled(false);
-        }
-    }
-
     private String getSelectedQuantity() {
         int checkedId = rgQuantity.getCheckedRadioButtonId();
         if (checkedId != -1) {
             RadioButton rb = findViewById(checkedId);
             return rb.getText().toString();
         }
-        return "N/A"; 
+        return "N/A";
     }
-
-    // REDUNDANT METHODS (logic moved to CardMakerActivity)
-    private void storeBirdDiscovery(String quantity) {}
-    private void getAndSetSlotIndexAndCreateUserBirdAndCollectionSlot(String userId, String userBirdId, String collectionSlotId, Date now, @Nullable String locationId, String quantity) {}
-    private void createUserBirdAndCollectionSlot(String userId, String userBirdId, String collectionSlotId, Date now, @Nullable String locationId, int slotIndex, String quantity) {}
-    private void saveUserBirdSighting(String userId, String userBirdId, Date timestamp, String quantity) {}
 }

--- a/app/src/main/java/com/birddex/app/CardMakerActivity.java
+++ b/app/src/main/java/com/birddex/app/CardMakerActivity.java
@@ -27,6 +27,8 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.Transaction;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -40,6 +42,7 @@ import java.util.UUID;
 public class CardMakerActivity extends AppCompatActivity {
 
     private static final String TAG = "CardMakerActivity";
+    private static final long HEATMAP_COOLDOWN_MS = 24L * 60L * 60L * 1000L;
 
     public static final String EXTRA_IMAGE_URI = "imageUri";
     public static final String EXTRA_BIRD_NAME = "birdName";
@@ -72,7 +75,7 @@ public class CardMakerActivity extends AppCompatActivity {
     private String currentLocality;
     private String currentState;
     private long currentCaughtTime;
-    
+
     private String currentQuantity;
     private boolean shouldRecordSighting;
     private Double currentLatitude;
@@ -112,7 +115,7 @@ public class CardMakerActivity extends AppCompatActivity {
         currentLocality = getIntent().getStringExtra(EXTRA_LOCALITY);
         currentState = getIntent().getStringExtra(EXTRA_STATE);
         currentCaughtTime = getIntent().getLongExtra(EXTRA_CAUGHT_TIME, System.currentTimeMillis());
-        
+
         currentQuantity = getIntent().getStringExtra(EXTRA_QUANTITY);
         shouldRecordSighting = getIntent().getBooleanExtra(EXTRA_RECORD_SIGHTING, false);
         currentLatitude = getIntent().hasExtra(EXTRA_LATITUDE) ? getIntent().getDoubleExtra(EXTRA_LATITUDE, 0.0) : null;
@@ -172,7 +175,7 @@ public class CardMakerActivity extends AppCompatActivity {
         StorageReference storageRef = FirebaseStorage.getInstance().getReference().child(originalImageFileName);
 
         Log.d(TAG, "processAndSaveBirdDiscovery: Uploading to " + originalImageFileName);
-        
+
         storageRef.putFile(originalImageUri)
                 .addOnSuccessListener(taskSnapshot -> {
                     storageRef.getDownloadUrl().addOnSuccessListener(originalDownloadUri -> {
@@ -315,7 +318,7 @@ public class CardMakerActivity extends AppCompatActivity {
 
         final TaskCompletionSource<Void> addSightingTcs = new TaskCompletionSource<>();
         if (shouldRecordSighting) {
-            saveUserBirdSighting(userId, userBirdId, now, currentQuantity, addSightingTcs);
+            saveUserBirdSightingIfAllowed(userId, userBirdId, now, currentQuantity, addSightingTcs);
         } else {
             addSightingTcs.setResult(null);
         }
@@ -330,6 +333,7 @@ public class CardMakerActivity extends AppCompatActivity {
                 .addOnSuccessListener(unused -> {
                     Log.d(TAG, "SUCCESS: All Firestore writes succeeded.");
                     loadingOverlay.setVisibility(View.GONE);
+
                     Toast.makeText(CardMakerActivity.this, "Saved to your collection!", Toast.LENGTH_SHORT).show();
 
                     Intent home = new Intent(CardMakerActivity.this, HomeActivity.class);
@@ -343,6 +347,71 @@ public class CardMakerActivity extends AppCompatActivity {
                     loadingOverlay.setVisibility(View.GONE);
                     Toast.makeText(CardMakerActivity.this, "Error saving to collection. Please try again.", Toast.LENGTH_LONG).show();
                 });
+    }
+
+    private void saveUserBirdSightingIfAllowed(String userId, String userBirdId, Date timestamp, String quantity, TaskCompletionSource<Void> tcs) {
+        if (currentBirdId == null || currentBirdId.trim().isEmpty()) {
+            Log.w(TAG, "Skipping heatmap upload: currentBirdId is missing.");
+            tcs.setResult(null);
+            return;
+        }
+
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        DocumentReference cooldownRef = db.collection("users")
+                .document(userId)
+                .collection("settings")
+                .document("heatmapCooldowns");
+
+        long nowMs = timestamp.getTime();
+
+        db.runTransaction((Transaction.Function<Boolean>) transaction -> {
+            com.google.firebase.firestore.DocumentSnapshot snapshot = transaction.get(cooldownRef);
+
+            Map<String, Object> speciesCooldowns = new HashMap<>();
+            Object rawCooldowns = snapshot.get("speciesCooldowns");
+            if (rawCooldowns instanceof Map) {
+                Map<?, ?> existing = (Map<?, ?>) rawCooldowns;
+                for (Map.Entry<?, ?> entry : existing.entrySet()) {
+                    if (entry.getKey() != null) {
+                        speciesCooldowns.put(String.valueOf(entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+
+            long lastUploadMs = 0L;
+            Object rawLastUpload = speciesCooldowns.get(currentBirdId);
+            if (rawLastUpload instanceof Number) {
+                lastUploadMs = ((Number) rawLastUpload).longValue();
+            }
+
+            boolean cooldownExpired = (nowMs - lastUploadMs) >= HEATMAP_COOLDOWN_MS;
+            if (cooldownExpired) {
+                speciesCooldowns.put(currentBirdId, nowMs);
+
+                Map<String, Object> cooldownDoc = new HashMap<>();
+                cooldownDoc.put("speciesCooldowns", speciesCooldowns);
+                cooldownDoc.put("updatedAt", nowMs);
+                transaction.set(cooldownRef, cooldownDoc);
+                return true;
+            }
+
+            return false;
+        }).addOnSuccessListener(canUpload -> {
+            if (Boolean.TRUE.equals(canUpload)) {
+                saveUserBirdSighting(userId, userBirdId, timestamp, quantity, tcs);
+            } else {
+                Log.d(TAG, "Heatmap cooldown active for birdId=" + currentBirdId + ". Skipping userBirdSighting write.");
+                Toast.makeText(
+                        CardMakerActivity.this,
+                        "Saved to collection. Heatmap upload skipped because this species was already uploaded in the last 24 hours.",
+                        Toast.LENGTH_LONG
+                ).show();
+                tcs.setResult(null);
+            }
+        }).addOnFailureListener(e -> {
+            Log.e(TAG, "Failed checking heatmap cooldown", e);
+            tcs.setException(e);
+        });
     }
 
     private void saveUserBirdSighting(String userId, String userBirdId, Date timestamp, String quantity, TaskCompletionSource<Void> tcs) {

--- a/app/src/main/java/com/birddex/app/NearbyFragment.java
+++ b/app/src/main/java/com/birddex/app/NearbyFragment.java
@@ -37,15 +37,19 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.Priority;
+import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -76,6 +80,7 @@ public class NearbyFragment extends Fragment {
     private String lastPlaceShown = null;
 
     private FirebaseManager firebaseManager;
+    private FirebaseFirestore db;
     private EbirdApi ebirdApi;
     private BirdCacheManager cacheManager;
 
@@ -92,6 +97,7 @@ public class NearbyFragment extends Fragment {
     private static final double SEARCH_RADIUS_METERS = 50000;
     private static final long SIGHTING_RECENCY_MS = 72L * 60 * 60 * 1000;
     private static final float MIN_DISTANCE_FOR_FETCH = 1000f;
+    private static final int MAX_USER_SIGHTINGS = 500;
 
     @Nullable
     @Override
@@ -114,6 +120,7 @@ public class NearbyFragment extends Fragment {
         rvNearby.setAdapter(adapter);
 
         firebaseManager = new FirebaseManager(requireContext());
+        db = FirebaseFirestore.getInstance();
         ebirdApi = new EbirdApi();
         cacheManager = new BirdCacheManager(requireContext());
 
@@ -296,9 +303,8 @@ public class NearbyFragment extends Fragment {
         if (currentLocation == null) return;
 
         fetchCount = 0;
-        Log.d(TAG, "Starting dual-fetch from Firestore and eBird...");
+        Log.d(TAG, "Starting dual-fetch from userBirdSightings and eBird...");
 
-        // Show inline progress bar and clear current list
         if (isAdded() && getActivity() != null) {
             getActivity().runOnUiThread(() -> {
                 pbLoading.setVisibility(View.VISIBLE);
@@ -311,39 +317,52 @@ public class NearbyFragment extends Fragment {
         firestoreBirds.clear();
         ebirdBirds.clear();
 
-        firebaseManager.getAllBirds(task -> {
-            if (task.isSuccessful() && task.getResult() != null) {
-                for (DocumentSnapshot doc : task.getResult().getDocuments()) {
-                    Bird bird = doc.toObject(Bird.class);
+        loadUserSightingsNearby();
+        loadEbirdNearby();
+    }
 
-                    if (bird != null && isBlank(bird.getId())) {
-                        bird.setId(doc.getId());
+    private void loadUserSightingsNearby() {
+        db.collection("userBirdSightings")
+                .limit(MAX_USER_SIGHTINGS)
+                .get()
+                .addOnSuccessListener(querySnapshot -> {
+                    firestoreBirds.clear();
+
+                    for (DocumentSnapshot doc : querySnapshot.getDocuments()) {
+                        Bird bird = mapUserSightingToBird(doc);
+                        if (isValidSighting(bird)) {
+                            firestoreBirds.add(bird);
+                            cacheSearchBird(bird);
+                        }
                     }
 
-                    if (bird != null) {
-                        cacheSearchBird(bird);
-                    }
+                    checkIfAllFetched();
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed loading userBirdSightings", e);
+                    checkIfAllFetched();
+                });
+    }
 
-                    if (isValidSighting(bird)) {
-                        firestoreBirds.add(bird);
-                    }
-                }
-            }
-            checkIfAllFetched();
-        });
-
+    private void loadEbirdNearby() {
         ebirdApi.fetchCoreGeorgiaBirdList(new EbirdApi.EbirdCoreBirdListCallback() {
             @Override
             public void onSuccess(List<JSONObject> birdsJson) {
+                ebirdBirds.clear();
+
                 for (JSONObject json : birdsJson) {
                     Bird bird = parseBirdJson(json);
-                    if (isValidSighting(bird)) ebirdBirds.add(bird);
+                    if (isValidSighting(bird)) {
+                        ebirdBirds.add(bird);
+                    }
                 }
+
                 checkIfAllFetched();
             }
 
             @Override
             public void onFailure(Exception e) {
+                Log.e(TAG, "Failed loading eBird nearby birds", e);
                 checkIfAllFetched();
             }
         });
@@ -354,6 +373,32 @@ public class NearbyFragment extends Fragment {
         if (fetchCount >= 2) {
             processFinalList();
         }
+    }
+
+    private Bird mapUserSightingToBird(DocumentSnapshot doc) {
+        Bird bird = new Bird();
+
+        String baseBirdId = getStringValue(doc, "birdId");
+        String commonName = getStringValue(doc, "commonName");
+        String scientificName = getStringValue(doc, "scientificName");
+        String species = getStringValue(doc, "species");
+        String family = getStringValue(doc, "family");
+
+        bird.setId(!isBlank(baseBirdId) ? baseBirdId : doc.getId());
+        bird.setCommonName(!isBlank(commonName) ? commonName : "Unknown bird");
+        bird.setScientificName(!isBlank(scientificName) ? scientificName : "");
+        bird.setSpecies(!isBlank(species) ? species : "");
+        bird.setFamily(!isBlank(family) ? family : "");
+
+        Double lat = getDoubleValue(doc, "location.latitude", "latitude", "lat", "lastSeenLatitudeGeorgia");
+        Double lng = getDoubleValue(doc, "location.longitude", "longitude", "lng", "lastSeenLongitudeGeorgia");
+        Long timeMillis = getTimeMillisValue(doc, "timestamp", "observationDate", "lastSeenTimestampGeorgia");
+
+        bird.setLastSeenLatitudeGeorgia(lat);
+        bird.setLastSeenLongitudeGeorgia(lng);
+        bird.setLastSeenTimestampGeorgia(timeMillis);
+
+        return bird;
     }
 
     private boolean isValidSighting(Bird bird) {
@@ -385,30 +430,38 @@ public class NearbyFragment extends Fragment {
         b.setId(json.optString("id"));
         b.setCommonName(json.optString("commonName"));
         b.setScientificName(json.optString("scientificName"));
-        b.setLastSeenLatitudeGeorgia(json.optDouble("lastSeenLatitudeGeorgia"));
-        b.setLastSeenLongitudeGeorgia(json.optDouble("lastSeenLongitudeGeorgia"));
-        b.setLastSeenTimestampGeorgia(json.optLong("lastSeenTimestampGeorgia"));
+
+        if (json.has("lastSeenLatitudeGeorgia") && !json.isNull("lastSeenLatitudeGeorgia")) {
+            b.setLastSeenLatitudeGeorgia(json.optDouble("lastSeenLatitudeGeorgia"));
+        }
+
+        if (json.has("lastSeenLongitudeGeorgia") && !json.isNull("lastSeenLongitudeGeorgia")) {
+            b.setLastSeenLongitudeGeorgia(json.optDouble("lastSeenLongitudeGeorgia"));
+        }
+
+        if (json.has("lastSeenTimestampGeorgia") && !json.isNull("lastSeenTimestampGeorgia")) {
+            b.setLastSeenTimestampGeorgia(json.optLong("lastSeenTimestampGeorgia"));
+        }
+
         return b;
     }
 
     private void processFinalList() {
-        List<Bird> combined = new ArrayList<>(firestoreBirds);
+        List<Bird> combined = new ArrayList<>();
+        combined.addAll(firestoreBirds);
+        combined.addAll(ebirdBirds);
 
-        for (Bird eb : ebirdBirds) {
-            boolean isDup = false;
-            for (Bird b : combined) {
-                if (b.getId() != null && b.getId().equals(eb.getId())) {
-                    isDup = true;
-                    break;
-                }
-            }
-            if (!isDup) combined.add(eb);
-        }
+        Collections.sort(combined, (b1, b2) -> {
+            Long t1 = b1.getLastSeenTimestampGeorgia();
+            Long t2 = b2.getLastSeenTimestampGeorgia();
 
-        Collections.sort(combined, (b1, b2) ->
-                b2.getLastSeenTimestampGeorgia().compareTo(b1.getLastSeenTimestampGeorgia()));
+            if (t1 == null && t2 == null) return 0;
+            if (t1 == null) return 1;
+            if (t2 == null) return -1;
 
-        // Save to cache
+            return t2.compareTo(t1);
+        });
+
         cacheManager.saveNearbyBirds(combined);
 
         if (isAdded() && getActivity() != null) {
@@ -633,6 +686,70 @@ public class NearbyFragment extends Fragment {
 
     private boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private String getStringValue(DocumentSnapshot doc, String... fieldPaths) {
+        for (String fieldPath : fieldPaths) {
+            Object value = getNestedValue(doc, fieldPath);
+            if (value != null) {
+                String text = String.valueOf(value).trim();
+                if (!text.isEmpty()) {
+                    return text;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Double getDoubleValue(DocumentSnapshot doc, String... fieldPaths) {
+        for (String fieldPath : fieldPaths) {
+            Object value = getNestedValue(doc, fieldPath);
+            if (value instanceof Number) {
+                return ((Number) value).doubleValue();
+            }
+        }
+        return null;
+    }
+
+    private Long getTimeMillisValue(DocumentSnapshot doc, String... fieldPaths) {
+        for (String fieldPath : fieldPaths) {
+            Object value = getNestedValue(doc, fieldPath);
+
+            if (value instanceof Timestamp) {
+                return ((Timestamp) value).toDate().getTime();
+            }
+
+            if (value instanceof Date) {
+                return ((Date) value).getTime();
+            }
+
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+        }
+        return null;
+    }
+
+    private Object getNestedValue(DocumentSnapshot doc, String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return null;
+        }
+
+        if (!path.contains(".")) {
+            return doc.get(path);
+        }
+
+        String[] parts = path.split("\\.");
+        Object current = doc.get(parts[0]);
+
+        for (int i = 1; i < parts.length; i++) {
+            if (!(current instanceof Map)) {
+                return null;
+            }
+            current = ((Map<?, ?>) current).get(parts[i]);
+        }
+
+        return current;
     }
 
     private static class SearchBirdItem {

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -47,13 +47,16 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.gms.maps.model.CameraPosition;
+import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.Source;
 import com.google.firebase.firestore.WriteBatch;
@@ -62,8 +65,6 @@ import com.google.firebase.storage.StorageReference;
 import com.google.maps.android.heatmaps.Gradient;
 import com.google.maps.android.heatmaps.HeatmapTileProvider;
 import com.google.maps.android.heatmaps.WeightedLatLng;
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
-import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,6 +83,11 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     public static final String EXTRA_CENTER_LNG = "extra_center_lng";
     private static final String PREFS_NAME = "BirdDexPrefs";
     private static final String KEY_GRAPHIC_CONTENT = "show_graphic_content";
+    private LatLngBounds currentVisibleBounds;
+    private float lastAppliedZoom = -1f;
+    private LatLng lastAppliedTarget;
+    private static final float MIN_ZOOM_CHANGE_TO_REFRESH = 0.5f;
+    private static final float MIN_CAMERA_MOVE_TO_REFRESH_METERS = 500f;
 
     private static final double DEFAULT_LAT = 32.6781;
     private static final double DEFAULT_LNG = -83.2220;
@@ -124,25 +130,26 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
     private final List<WeightedLatLng> userHeatPoints = new ArrayList<>();
     private final List<WeightedLatLng> eBirdHeatPoints = new ArrayList<>();
+    private final List<HotspotSighting> userHotspotSightings = new ArrayList<>();
+    private final List<HotspotSighting> eBirdHotspotSightings = new ArrayList<>();
 
     private final Map<String, HotspotBucket> hotspotBuckets = new LinkedHashMap<>();
     private final List<Circle> hotspotCircles = new ArrayList<>();
     private final Map<String, HotspotBucket> circleIdToBucket = new HashMap<>();
-    
+
     private final List<Marker> forumMarkers = new ArrayList<>();
 
     private double centerLat = Double.NaN;
     private double centerLng = Double.NaN;
 
     private int pendingLoads = 0;
-    
+
     private ForumComment replyingToComment = null;
     private EditText currentPopupEditText;
     private ForumPost activePost;
     private FirebaseManager firebaseManager;
     private ForumCommentAdapter popupCommentAdapter;
 
-    // Pagination for popup comments
     private List<ForumComment> popupCommentList = new ArrayList<>();
     private DocumentSnapshot lastPopupCommentVisible;
     private boolean isFetchingPopupComments = false;
@@ -205,26 +212,79 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             }
         }
 
-        fetchHeatmapData();
-        loadForumPins();
+        googleMap.setOnCameraIdleListener(() -> {
+            if (googleMap == null) return;
+
+            CameraPosition cameraPosition = googleMap.getCameraPosition();
+            LatLng target = cameraPosition.target;
+            float zoom = cameraPosition.zoom;
+
+            currentVisibleBounds = googleMap.getProjection().getVisibleRegion().latLngBounds;
+
+            // keep your nearby-center behavior in sync with the actual map center
+            centerLat = target.latitude;
+            centerLng = target.longitude;
+
+            boolean shouldRefresh = false;
+
+            if (lastAppliedTarget == null) {
+                shouldRefresh = true;
+            } else {
+                float[] results = new float[1];
+                android.location.Location.distanceBetween(
+                        lastAppliedTarget.latitude,
+                        lastAppliedTarget.longitude,
+                        target.latitude,
+                        target.longitude,
+                        results
+                );
+
+                float movedMeters = results[0];
+                float zoomDiff = Math.abs(zoom - lastAppliedZoom);
+
+                if (movedMeters >= MIN_CAMERA_MOVE_TO_REFRESH_METERS ||
+                        zoomDiff >= MIN_ZOOM_CHANGE_TO_REFRESH) {
+                    shouldRefresh = true;
+                }
+            }
+
+            if (shouldRefresh) {
+                lastAppliedTarget = target;
+                lastAppliedZoom = zoom;
+                fetchHeatmapData();
+                loadForumPins();
+            }
+        });
+
+        // initial visible bounds
+        googleMap.setOnMapLoadedCallback(() -> {
+            if (googleMap != null) {
+                currentVisibleBounds = googleMap.getProjection().getVisibleRegion().latLngBounds;
+                CameraPosition cameraPosition = googleMap.getCameraPosition();
+                lastAppliedTarget = cameraPosition.target;
+                lastAppliedZoom = cameraPosition.zoom;
+                fetchHeatmapData();
+                loadForumPins();
+            }
+        });
     }
 
     private void fetchHeatmapData() {
         pendingLoads = 2;
         userHeatPoints.clear();
         eBirdHeatPoints.clear();
+        userHotspotSightings.clear();
+        eBirdHotspotSightings.clear();
         hotspotBuckets.clear();
         clearHotspotCircles();
 
         tvMapSubtitle.setText("Loading heatmap...");
 
-        // Heatmap data is heavy, so we try CACHE first
         loadUserBirdSightings();
         loadEbirdApiSightings();
     }
 
     private void loadForumPins() {
-        // We removed the hard limit here to show all pins
         db.collection("forumThreads")
                 .whereEqualTo("showLocation", true)
                 .get(Source.CACHE)
@@ -254,7 +314,15 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             ForumPost post = doc.toObject(ForumPost.class);
             if (post != null && post.getLatitude() != null && post.getLongitude() != null) {
                 post.setId(doc.getId());
-                if (showGraphicContent || !post.isHunted()) {
+
+                boolean inVisibleBounds = true;
+                if (currentVisibleBounds != null) {
+                    inVisibleBounds = currentVisibleBounds.contains(
+                            new LatLng(post.getLatitude(), post.getLongitude())
+                    );
+                }
+
+                if (inVisibleBounds && (showGraphicContent || !post.isHunted())) {
                     addPinToMap(post);
                 }
             }
@@ -263,11 +331,11 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
     private void addPinToMap(ForumPost post) {
         LatLng pos = new LatLng(post.getLatitude(), post.getLongitude());
-        
+
         StringBuilder status = new StringBuilder();
         if (post.isSpotted()) status.append("Spotted ");
         if (post.isHunted()) status.append("Hunted ");
-        
+
         String title = post.getUsername() + (status.length() > 0 ? " (" + status.toString().trim() + ")" : "");
 
         BitmapDescriptor pinIcon;
@@ -276,7 +344,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         } else if (post.isHunted()) {
             pinIcon = createColoredPin(Color.BLACK);
         } else if (post.isSpotted()) {
-            pinIcon = createColoredPin(Color.rgb(255, 165, 0)); // Orange
+            pinIcon = createColoredPin(Color.rgb(255, 165, 0));
         } else {
             pinIcon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE);
         }
@@ -301,10 +369,10 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         Paint paint = new Paint();
         paint.setColor(color);
         paint.setAntiAlias(true);
-        
+
         canvas.drawCircle(size / 2f, size / 3f, size / 3f, paint);
         canvas.drawRect(size / 2f - 4, size / 2f, size / 2f + 4, size * 0.9f, paint);
-        
+
         return BitmapDescriptorFactory.fromBitmap(bitmap);
     }
 
@@ -316,10 +384,10 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         paint.setAntiAlias(true);
 
         paint.setColor(Color.BLUE);
-        canvas.drawArc(size / 6f, 0, size * 5/6f, size * 2/3f, 90, 180, true, paint);
-        
+        canvas.drawArc(size / 6f, 0, size * 5 / 6f, size * 2 / 3f, 90, 180, true, paint);
+
         paint.setColor(Color.BLACK);
-        canvas.drawArc(size / 6f, 0, size * 5/6f, size * 2/3f, 270, 180, true, paint);
+        canvas.drawArc(size / 6f, 0, size * 5 / 6f, size * 2 / 3f, 270, 180, true, paint);
 
         paint.setColor(Color.BLUE);
         canvas.drawRect(size / 2f - 4, size / 2f, size / 2f, size * 0.9f, paint);
@@ -361,7 +429,6 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             }
         }
 
-        // Bind Post Data
         View postContent = view.findViewById(R.id.postContent);
         TextView tvUsername = postContent.findViewById(R.id.tvPostUsername);
         TextView tvTimestamp = postContent.findViewById(R.id.tvPostTimestamp);
@@ -373,7 +440,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         TextView tvComments = postContent.findViewById(R.id.tvCommentCount);
         TextView tvViews = postContent.findViewById(R.id.tvViewCount);
         View btnPostOptions = postContent.findViewById(R.id.btnPostOptions);
-        
+
         TextView tvSpottedBadge = postContent.findViewById(R.id.tvSpottedBadge);
         TextView tvHuntedBadge = postContent.findViewById(R.id.tvHuntedBadge);
 
@@ -382,7 +449,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         tvLikes.setText(String.valueOf(post.getLikeCount()));
         tvComments.setText(String.valueOf(post.getCommentCount()));
         tvViews.setText(post.getViewCount() + " views");
-        
+
         if (tvSpottedBadge != null) tvSpottedBadge.setVisibility(post.isSpotted() ? View.VISIBLE : View.GONE);
         if (tvHuntedBadge != null) tvHuntedBadge.setVisibility(post.isHunted() ? View.VISIBLE : View.GONE);
 
@@ -391,7 +458,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         }
 
         Glide.with(this).load(post.getUserProfilePictureUrl()).placeholder(R.drawable.ic_profile).into(ivPfp);
-        
+
         if (post.getBirdImageUrl() != null && !post.getBirdImageUrl().isEmpty()) {
             cvImage.setVisibility(View.VISIBLE);
             Glide.with(this).load(post.getBirdImageUrl()).into(ivBird);
@@ -408,7 +475,6 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
         btnPostOptions.setOnClickListener(v -> showPostOptions(post, v, dialog));
 
-        // Setup Comments with Pagination
         RecyclerView rvComments = view.findViewById(R.id.rvComments);
         popupCommentAdapter = new ForumCommentAdapter(this);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
@@ -465,25 +531,23 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                     comment.setParentCommentId(replyingToComment.getId());
                     comment.setParentUsername(replyingToComment.getUsername());
                 }
-                
+
                 WriteBatch batch = db.batch();
                 DocumentReference commentRef = db.collection("forumThreads").document(post.getId()).collection("comments").document();
                 batch.set(commentRef, comment);
                 batch.update(db.collection("forumThreads").document(post.getId()), "commentCount", FieldValue.increment(1));
-                
+
                 batch.commit().addOnSuccessListener(aVoid -> {
                     currentPopupEditText.setText("");
                     currentPopupEditText.setHint("Write a comment...");
                     replyingToComment = null;
-                    
-                    // Simple refresh
                     refreshPopupComments();
                 });
             });
         });
 
         dialog.show();
-        
+
         View bottomSheet = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
         if (bottomSheet != null) {
             BottomSheetBehavior<View> behavior = BottomSheetBehavior.from(bottomSheet);
@@ -536,7 +600,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     private void showPostOptions(ForumPost post, View view, BottomSheetDialog dialog) {
         PopupMenu popup = new PopupMenu(this, view);
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-        
+
         if (user != null && post.getUserId().equals(user.getUid())) {
             popup.getMenu().add("Delete");
         }
@@ -593,7 +657,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                 .get()
                 .addOnSuccessListener(queryDocumentSnapshots -> {
                     WriteBatch batch = db.batch();
-                    
+
                     for (DocumentSnapshot doc : queryDocumentSnapshots) {
                         Map<String, Object> commentBacklog = new HashMap<>();
                         commentBacklog.put("type", "comment_archived_with_post");
@@ -602,21 +666,21 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                         commentBacklog.put("data", doc.getData());
                         commentBacklog.put("deletedBy", userId);
                         commentBacklog.put("deletedAt", FieldValue.serverTimestamp());
-                        
+
                         batch.set(db.collection("deletedforum_backlog").document(), commentBacklog);
                         batch.delete(doc.getReference());
                     }
-                    
+
                     Map<String, Object> postBacklog = new HashMap<>();
                     postBacklog.put("type", "post");
                     postBacklog.put("originalId", post.getId());
                     postBacklog.put("data", post);
                     postBacklog.put("deletedBy", userId);
                     postBacklog.put("deletedAt", FieldValue.serverTimestamp());
-                    
+
                     batch.set(db.collection("deletedforum_backlog").document(), postBacklog);
                     batch.delete(db.collection("forumThreads").document(post.getId()));
-                    
+
                     batch.commit().addOnSuccessListener(aVoid -> {
                         Toast.makeText(this, "Post and comments deleted", Toast.LENGTH_SHORT).show();
                         if (bottomSheetDialog != null) bottomSheetDialog.dismiss();
@@ -782,7 +846,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     public void onCommentOptionsClick(ForumComment comment, View view) {
         PopupMenu popup = new PopupMenu(this, view);
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-        
+
         boolean isCommentAuthor = user != null && comment.getUserId().equals(user.getUid());
 
         if (isCommentAuthor) {
@@ -828,15 +892,15 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                             backlogByUserId(batch, user.getUid(), "comment_reply", doc.getId(), doc.getData());
                             batch.delete(doc.getReference());
                         }
-                        
+
                         backlogByUserId(batch, user.getUid(), "comment", comment.getId(), comment);
 
                         batch.delete(db.collection("forumThreads").document(activePost.getId())
                                 .collection("comments").document(comment.getId()));
-                        
-                        batch.update(db.collection("forumThreads").document(activePost.getId()), 
+
+                        batch.update(db.collection("forumThreads").document(activePost.getId()),
                                 "commentCount", FieldValue.increment(-totalToDelete));
-                        
+
                         batch.commit().addOnSuccessListener(aVoid -> {
                             Toast.makeText(this, "Comment deleted", Toast.LENGTH_SHORT).show();
                             refreshPopupComments();
@@ -882,7 +946,6 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     }
 
     private void loadUserBirdSightings() {
-        // Fetch sightings from CACHE first
         db.collection("userBirdSightings")
                 .limit(500)
                 .get(Source.CACHE)
@@ -925,8 +988,11 @@ public class NearbyHeatmapActivity extends AppCompatActivity
     }
 
     private void processSightings(com.google.firebase.firestore.QuerySnapshot querySnapshot, boolean isUserSighting) {
-        if (isUserSighting) userHeatPoints.clear();
-        else eBirdHeatPoints.clear();
+        List<WeightedLatLng> targetHeatPoints = isUserSighting ? userHeatPoints : eBirdHeatPoints;
+        List<HotspotSighting> targetHotspotSightings = isUserSighting ? userHotspotSightings : eBirdHotspotSightings;
+
+        targetHeatPoints.clear();
+        targetHotspotSightings.clear();
 
         for (DocumentSnapshot doc : querySnapshot.getDocuments()) {
             Double lat = getAnyDouble(doc, "location.latitude", "lastSeenLatitudeGeorgia", "latitude", "lat");
@@ -936,18 +1002,35 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             if (lat == null || lng == null) continue;
             if (shouldBeFiltered(lat, lng, timeMillis)) continue;
 
-            if (isUserSighting) userHeatPoints.add(new WeightedLatLng(new LatLng(lat, lng), 1.8));
-            else eBirdHeatPoints.add(new WeightedLatLng(new LatLng(lat, lng), 1.0));
+            if (isUserSighting) {
+                targetHeatPoints.add(new WeightedLatLng(new LatLng(lat, lng), 1.8));
+            } else {
+                targetHeatPoints.add(new WeightedLatLng(new LatLng(lat, lng), 1.0));
+            }
 
             String birdName = extractBirdName(doc);
-            addToHotspotBucket(lat, lng, birdName, isUserSighting);
+            targetHotspotSightings.add(new HotspotSighting(lat, lng, birdName, isUserSighting));
         }
+
+        rebuildHotspotBuckets();
         onCollectionFinished();
     }
 
     private void onCollectionFinished() {
         pendingLoads--;
         if (pendingLoads <= 0) renderHeatmaps();
+    }
+
+    private void rebuildHotspotBuckets() {
+        hotspotBuckets.clear();
+
+        for (HotspotSighting sighting : userHotspotSightings) {
+            addToHotspotBucket(sighting.lat, sighting.lng, sighting.birdName, true);
+        }
+
+        for (HotspotSighting sighting : eBirdHotspotSightings) {
+            addToHotspotBucket(sighting.lat, sighting.lng, sighting.birdName, false);
+        }
     }
 
     private void renderHeatmaps() {
@@ -1191,7 +1274,14 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             }
         }
 
-        if (hasNearbyCenter()) {
+        // When map bounds are available, filter by what is actually visible on screen.
+        if (currentVisibleBounds != null) {
+            LatLng point = new LatLng(lat, lng);
+            if (!currentVisibleBounds.contains(point)) {
+                return true;
+            }
+        } else if (hasNearbyCenter()) {
+            // fallback to old 50km center-radius behavior
             float[] results = new float[1];
             android.location.Location.distanceBetween(
                     centerLat,
@@ -1201,7 +1291,9 @@ public class NearbyHeatmapActivity extends AppCompatActivity
                     results
             );
 
-            return results[0] > SEARCH_RADIUS_METERS;
+            if (results[0] > SEARCH_RADIUS_METERS) {
+                return true;
+            }
         }
 
         return false;
@@ -1252,6 +1344,20 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             }
         }
         return null;
+    }
+
+    private static class HotspotSighting {
+        final double lat;
+        final double lng;
+        final String birdName;
+        final boolean isUserSighting;
+
+        HotspotSighting(double lat, double lng, String birdName, boolean isUserSighting) {
+            this.lat = lat;
+            this.lng = lng;
+            this.birdName = birdName;
+            this.isUserSighting = isUserSighting;
+        }
     }
 
     private static class HotspotBucket {

--- a/app/src/main/res/layout/activity_bird_info.xml
+++ b/app/src/main/res/layout/activity_bird_info.xml
@@ -37,8 +37,8 @@
                 android:text="Common Name: "
                 android:textSize="18sp"
                 android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/birdImageView" />
 
             <TextView
@@ -50,8 +50,8 @@
                 android:gravity="center"
                 android:text="Scientific Name: "
                 android:textSize="16sp"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/commonNameTextView" />
 
             <TextView
@@ -63,8 +63,8 @@
                 android:gravity="center"
                 android:text="Species: "
                 android:textSize="16sp"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/scientificNameTextView" />
 
             <TextView
@@ -76,8 +76,8 @@
                 android:gravity="center"
                 android:text="Family: "
                 android:textSize="16sp"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/speciesTextView" />
 
             <View
@@ -87,45 +87,9 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginHorizontal="32dp"
                 android:background="#CCCCCC"
-                app:layout_constraintTop_toBottomOf="@id/familyTextView"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-
-            <TextView
-                android:id="@+id/tvSpotQuestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:text="Did you spot this bird?"
-                android:textSize="18sp"
-                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/divider" />
-
-            <LinearLayout
-                android:id="@+id/layoutYesNo"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tvSpotQuestion">
-
-                <CheckBox
-                    android:id="@+id/cbYes"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
-                    android:text="Yes" />
-
-                <CheckBox
-                    android:id="@+id/cbNo"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="No" />
-            </LinearLayout>
+                app:layout_constraintTop_toBottomOf="@id/familyTextView" />
 
             <LinearLayout
                 android:id="@+id/layoutQuantity"
@@ -135,17 +99,17 @@
                 android:layout_marginHorizontal="24dp"
                 android:gravity="center"
                 android:orientation="vertical"
-                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layoutYesNo"
-                tools:visibility="visible">
+                app:layout_constraintTop_toBottomOf="@id/divider">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="How many did you see?"
-                    android:textSize="16sp" />
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
 
                 <RadioGroup
                     android:id="@+id/rgQuantity"
@@ -180,6 +144,20 @@
                 </RadioGroup>
             </LinearLayout>
 
+            <TextView
+                android:id="@+id/tvHeatmapDisclaimer"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginHorizontal="24dp"
+                android:gravity="center"
+                android:text='Saving this image can add one heatmap sighting for this species. Heatmap uploads for the same bird are limited to once every 24 hours per user.'
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layoutQuantity" />
+
             <Button
                 android:id="@+id/btnStore"
                 android:layout_width="0dp"
@@ -190,7 +168,7 @@
                 android:text="Use This Picture"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layoutQuantity" />
+                app:layout_constraintTop_toBottomOf="@id/tvHeatmapDisclaimer" />
 
             <Button
                 android:id="@+id/btnDiscard"


### PR DESCRIPTION
… and optimized map data fetching.

- Implemented `saveUserBirdSightingIfAllowed` in `CardMakerActivity` to enforce a 24-hour cooldown per species for heatmap uploads.
- Updated `NearbyHeatmapActivity` to refresh data based on camera movement (distance/zoom) and visible bounds rather than a fixed radius.
- Refactored `NearbyFragment` to use a dedicated `userBirdSightings` collection for dual-fetching with eBird, including improved field mapping for Firestore documents.
- Simplified `BirdInfoActivity` UI by removing the manual spotting toggle and adding a heatmap upload disclaimer.
- Improved heatmap performance by caching sightings and rebuilding buckets locally on camera changes.
- Added support for nested field extraction (e.g., `location.latitude`) and diverse timestamp formats in Firestore document mapping.