### PR TITLE
Refactored Firestore write logic in `CardMakerActivity` to prioritize…

### DIFF
--- a/app/src/main/java/com/birddex/app/CardMakerActivity.java
+++ b/app/src/main/java/com/birddex/app/CardMakerActivity.java
@@ -323,15 +323,28 @@ public class CardMakerActivity extends AppCompatActivity {
             addSightingTcs.setResult(null);
         }
 
-        Tasks.whenAll(
-                        addLocationTcs.getTask(),
-                        addUserBirdTcs.getTask(),
-                        addUserBirdImageTcs.getTask(),
-                        addCollectionSlotMaybeTcs.getTask(),
-                        addSightingTcs.getTask()
-                )
+        Task<Void> coreCollectionTask = Tasks.whenAll(
+                addUserBirdTcs.getTask(),
+                addUserBirdImageTcs.getTask(),
+                addCollectionSlotMaybeTcs.getTask()
+        );
+
+        coreCollectionTask
                 .addOnSuccessListener(unused -> {
-                    Log.d(TAG, "SUCCESS: All Firestore writes succeeded.");
+                    Log.d(TAG, "SUCCESS: Core collection writes succeeded.");
+
+                    addLocationTcs.getTask()
+                            .addOnSuccessListener(locationUnused ->
+                                    Log.d(TAG, "SUCCESS: Location saved."))
+                            .addOnFailureListener(e ->
+                                    Log.w(TAG, "Location write failed, but collection save already succeeded.", e));
+
+                    addSightingTcs.getTask()
+                            .addOnSuccessListener(sightingUnused ->
+                                    Log.d(TAG, "SUCCESS: Optional sighting flow completed."))
+                            .addOnFailureListener(e ->
+                                    Log.w(TAG, "Sighting write failed, but collection save already succeeded.", e));
+
                     loadingOverlay.setVisibility(View.GONE);
 
                     Toast.makeText(CardMakerActivity.this, "Saved to your collection!", Toast.LENGTH_SHORT).show();
@@ -343,7 +356,7 @@ public class CardMakerActivity extends AppCompatActivity {
                     finish();
                 })
                 .addOnFailureListener(e -> {
-                    Log.e(TAG, "FAILURE: One or more Firestore writes failed.", e);
+                    Log.e(TAG, "FAILURE: Core collection save failed.", e);
                     loadingOverlay.setVisibility(View.GONE);
                     Toast.makeText(CardMakerActivity.this, "Error saving to collection. Please try again.", Toast.LENGTH_LONG).show();
                 });


### PR DESCRIPTION
… core collection tasks.

- Decoupled `addUserBird`, `addUserBirdImage`, and `addCollectionSlotMaybe` as core tasks that must succeed to trigger the success UI.
- Moved `addLocation` and `addSighting` tasks into asynchronous callbacks that log errors without failing the overall collection save process.
- Updated logging and toast messages to reflect that the collection save is successful even if optional location or sighting data fails to write.