### PR TITLE
BugFixed the likes populating on the comments and replies.

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumCommentAdapter.java
+++ b/app/src/main/java/com/birddex/app/ForumCommentAdapter.java
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.google.firebase.auth.FirebaseAuth;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -26,6 +27,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
     private List<ForumComment> topLevelComments = new ArrayList<>();
     private OnCommentInteractionListener listener;
     private Set<String> expandedCommentIds = new HashSet<>();
+    private String currentUserId;
 
     public interface OnCommentInteractionListener {
         void onCommentLikeClick(ForumComment comment);
@@ -36,6 +38,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
 
     public ForumCommentAdapter(OnCommentInteractionListener listener) {
         this.listener = listener;
+        this.currentUserId = FirebaseAuth.getInstance().getUid();
     }
 
     public void setComments(List<ForumComment> comments) {
@@ -61,7 +64,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                 .collect(Collectors.toList());
         
         boolean isExpanded = expandedCommentIds.contains(comment.getId());
-        holder.bind(comment, replies, isExpanded, listener, (id, expand) -> {
+        holder.bind(comment, replies, isExpanded, listener, currentUserId, (id, expand) -> {
             if (expand) expandedCommentIds.add(id);
             else expandedCommentIds.remove(id);
             notifyItemChanged(position);
@@ -109,7 +112,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
             llActions = itemView.findViewById(R.id.llActions);
         }
 
-        public void bind(ForumComment comment, List<ForumComment> replies, boolean isExpanded, OnCommentInteractionListener listener, OnExpandListener expandListener) {
+        public void bind(ForumComment comment, List<ForumComment> replies, boolean isExpanded, OnCommentInteractionListener listener, String currentUserId, OnExpandListener expandListener) {
             tvUsername.setText(comment.getUsername());
             tvText.setText(comment.getText());
             tvLikeCount.setText(String.valueOf(comment.getLikeCount()));
@@ -132,6 +135,13 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                     .placeholder(R.drawable.ic_profile)
                     .into(ivUserPfp);
 
+            // Like status icon update
+            if (currentUserId != null && comment.getLikedBy() != null && comment.getLikedBy().containsKey(currentUserId)) {
+                ivLikeIcon.setImageResource(R.drawable.ic_favorite);
+            } else {
+                ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
+            }
+
             btnLike.setOnClickListener(v -> listener.onCommentLikeClick(comment));
             btnReply.setOnClickListener(v -> listener.onCommentReplyClick(comment));
             btnOptions.setOnClickListener(v -> listener.onCommentOptionsClick(comment, v));
@@ -146,7 +156,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                     
                     rvReplies.setVisibility(View.VISIBLE);
                     rvReplies.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
-                    rvReplies.setAdapter(new ReplyAdapter(replies, listener));
+                    rvReplies.setAdapter(new ReplyAdapter(replies, listener, currentUserId));
                 } else {
                     tvShowReplies.setVisibility(View.VISIBLE);
                     int remainingCount = replies.size() - 1;
@@ -161,7 +171,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                     rvReplies.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
                     List<ForumComment> firstReplyOnly = new ArrayList<>();
                     firstReplyOnly.add(replies.get(0));
-                    rvReplies.setAdapter(new ReplyAdapter(firstReplyOnly, listener));
+                    rvReplies.setAdapter(new ReplyAdapter(firstReplyOnly, listener, currentUserId));
                 }
             } else {
                 tvShowReplies.setVisibility(View.GONE);
@@ -173,10 +183,12 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
     static class ReplyAdapter extends RecyclerView.Adapter<ReplyAdapter.ReplyViewHolder> {
         private List<ForumComment> replies;
         private OnCommentInteractionListener listener;
+        private String currentUserId;
 
-        ReplyAdapter(List<ForumComment> replies, OnCommentInteractionListener listener) {
+        ReplyAdapter(List<ForumComment> replies, OnCommentInteractionListener listener, String currentUserId) {
             this.replies = replies;
             this.listener = listener;
+            this.currentUserId = currentUserId;
         }
 
         @NonNull
@@ -188,7 +200,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
 
         @Override
         public void onBindViewHolder(@NonNull ReplyViewHolder holder, int position) {
-            holder.bind(replies.get(position), listener);
+            holder.bind(replies.get(position), listener, currentUserId);
         }
 
         @Override
@@ -202,6 +214,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
             TextView tvTimestamp;
             TextView tvText;
             LinearLayout btnLike;
+            ImageView ivLikeIcon;
             TextView tvLikeCount;
             RecyclerView rvReplies;
             TextView tvReplyingTo;
@@ -215,6 +228,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                 tvTimestamp = itemView.findViewById(R.id.tvCommentTimestamp);
                 tvText = itemView.findViewById(R.id.tvCommentText);
                 btnLike = itemView.findViewById(R.id.btnLikeComment);
+                ivLikeIcon = itemView.findViewById(R.id.ivCommentLikeIcon);
                 tvLikeCount = itemView.findViewById(R.id.tvCommentLikeCount);
                 rvReplies = itemView.findViewById(R.id.rvReplies);
                 tvReplyingTo = itemView.findViewById(R.id.tvReplyingTo);
@@ -226,7 +240,7 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                 rvReplies.setVisibility(View.GONE);
             }
 
-            void bind(ForumComment reply, OnCommentInteractionListener listener) {
+            void bind(ForumComment reply, OnCommentInteractionListener listener, String currentUserId) {
                 tvUsername.setText(reply.getUsername());
                 tvText.setText(reply.getText());
                 tvLikeCount.setText(String.valueOf(reply.getLikeCount()));
@@ -247,6 +261,13 @@ public class ForumCommentAdapter extends RecyclerView.Adapter<ForumCommentAdapte
                         .load(reply.getUserProfilePictureUrl())
                         .placeholder(R.drawable.ic_profile)
                         .into(ivUserPfp);
+
+                // Like status icon update
+                if (currentUserId != null && reply.getLikedBy() != null && reply.getLikedBy().containsKey(currentUserId)) {
+                    ivLikeIcon.setImageResource(R.drawable.ic_favorite);
+                } else {
+                    ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
+                }
 
                 btnLike.setOnClickListener(v -> listener.onCommentLikeClick(reply));
                 btnOptions.setOnClickListener(v -> listener.onCommentOptionsClick(reply, v));

--- a/app/src/main/java/com/birddex/app/ForumPostAdapter.java
+++ b/app/src/main/java/com/birddex/app/ForumPostAdapter.java
@@ -151,7 +151,7 @@ public class ForumPostAdapter extends RecyclerView.Adapter<ForumPostAdapter.Post
             // Like status
             String currentUserId = FirebaseAuth.getInstance().getUid();
             if (currentUserId != null && post.getLikedBy() != null && post.getLikedBy().containsKey(currentUserId)) {
-                ivLikeIcon.setImageResource(R.drawable.ic_favorite_border); // Placeholder - should be filled heart
+                ivLikeIcon.setImageResource(R.drawable.ic_favorite);
             } else {
                 ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
             }

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -440,6 +440,8 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         TextView tvComments = postContent.findViewById(R.id.tvCommentCount);
         TextView tvViews = postContent.findViewById(R.id.tvViewCount);
         View btnPostOptions = postContent.findViewById(R.id.btnPostOptions);
+        ImageView ivLikeIcon = postContent.findViewById(R.id.ivLikeIcon);
+        View btnLike = postContent.findViewById(R.id.btnLike);
 
         TextView tvSpottedBadge = postContent.findViewById(R.id.tvSpottedBadge);
         TextView tvHuntedBadge = postContent.findViewById(R.id.tvHuntedBadge);
@@ -465,6 +467,44 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         } else {
             cvImage.setVisibility(View.GONE);
         }
+
+        // Update like icon for post
+        if (user != null && post.getLikedBy() != null && post.getLikedBy().containsKey(user.getUid())) {
+            ivLikeIcon.setImageResource(R.drawable.ic_favorite);
+        } else {
+            ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
+        }
+
+        btnLike.setOnClickListener(v -> {
+            if (user == null) return;
+            String userId = user.getUid();
+            boolean liked = post.getLikedBy() != null && post.getLikedBy().containsKey(userId);
+            int currentCount = post.getLikeCount();
+
+            if (liked) {
+                post.setLikeCount(Math.max(0, currentCount - 1));
+                post.getLikedBy().remove(userId);
+                ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
+            } else {
+                post.setLikeCount(currentCount + 1);
+                if (post.getLikedBy() == null) post.setLikedBy(new HashMap<>());
+                post.getLikedBy().put(userId, true);
+                ivLikeIcon.setImageResource(R.drawable.ic_favorite);
+            }
+            tvLikes.setText(String.valueOf(post.getLikeCount()));
+
+            db.collection("forumThreads").document(post.getId())
+                    .update("likeCount", FieldValue.increment(liked ? -1 : 1),
+                            "likedBy." + userId, liked ? FieldValue.delete() : true)
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        post.setLikeCount(currentCount);
+                        if (liked) post.getLikedBy().put(userId, true);
+                        else post.getLikedBy().remove(userId);
+                        tvLikes.setText(String.valueOf(post.getLikeCount()));
+                        ivLikeIcon.setImageResource(liked ? R.drawable.ic_favorite : R.drawable.ic_favorite_border);
+                    });
+        });
 
         postContent.setOnClickListener(v -> {
             Intent intent = new Intent(this, PostDetailActivity.class);
@@ -820,16 +860,40 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         if (user == null || activePost == null) return;
 
         String userId = user.getUid();
-        boolean liked = comment.getLikedBy() != null && comment.getLikedBy().containsKey(userId);
+        if (comment.getLikedBy() == null) comment.setLikedBy(new HashMap<>());
+        boolean liked = comment.getLikedBy().containsKey(userId);
+
+        // Optimistic UI Update
+        int currentCount = comment.getLikeCount();
+        if (liked) {
+            comment.setLikeCount(Math.max(0, currentCount - 1));
+            comment.getLikedBy().remove(userId);
+        } else {
+            comment.setLikeCount(currentCount + 1);
+            comment.getLikedBy().put(userId, true);
+        }
+        if (popupCommentAdapter != null) popupCommentAdapter.notifyDataSetChanged();
 
         if (liked) {
             db.collection("forumThreads").document(activePost.getId()).collection("comments").document(comment.getId())
                     .update("likeCount", FieldValue.increment(-1),
-                            "likedBy." + userId, FieldValue.delete());
+                            "likedBy." + userId, FieldValue.delete())
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        comment.setLikeCount(currentCount);
+                        comment.getLikedBy().put(userId, true);
+                        if (popupCommentAdapter != null) popupCommentAdapter.notifyDataSetChanged();
+                    });
         } else {
             db.collection("forumThreads").document(activePost.getId()).collection("comments").document(comment.getId())
                     .update("likeCount", FieldValue.increment(1),
-                            "likedBy." + userId, true);
+                            "likedBy." + userId, true)
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        comment.setLikeCount(currentCount);
+                        comment.getLikedBy().remove(userId);
+                        if (popupCommentAdapter != null) popupCommentAdapter.notifyDataSetChanged();
+                    });
         }
     }
 

--- a/app/src/main/java/com/birddex/app/PostDetailActivity.java
+++ b/app/src/main/java/com/birddex/app/PostDetailActivity.java
@@ -174,6 +174,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
         TextView tvLikes = postView.findViewById(R.id.tvLikeCount);
         TextView tvComments = postView.findViewById(R.id.tvCommentCount);
         TextView tvViews = postView.findViewById(R.id.tvViewCount);
+        ImageView ivLikeIcon = postView.findViewById(R.id.ivLikeIcon);
         View btnLike = postView.findViewById(R.id.btnLike);
         View btnOptions = postView.findViewById(R.id.btnPostOptions);
         View btnViewOnMap = postView.findViewById(R.id.btnViewOnMap);
@@ -221,6 +222,14 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
             } else {
                 btnViewOnMap.setVisibility(View.GONE);
             }
+        }
+
+        // Like status icon update
+        FirebaseUser currentUser = mAuth.getCurrentUser();
+        if (currentUser != null && post.getLikedBy() != null && post.getLikedBy().containsKey(currentUser.getUid())) {
+            ivLikeIcon.setImageResource(R.drawable.ic_favorite);
+        } else {
+            ivLikeIcon.setImageResource(R.drawable.ic_favorite_border);
         }
 
         btnLike.setOnClickListener(v -> toggleLike());
@@ -482,16 +491,40 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
         if (user == null || originalPost == null) return;
 
         String userId = user.getUid();
-        boolean liked = originalPost.getLikedBy() != null && originalPost.getLikedBy().containsKey(userId);
+        if (originalPost.getLikedBy() == null) originalPost.setLikedBy(new HashMap<>());
+        boolean liked = originalPost.getLikedBy().containsKey(userId);
+
+        // Optimistic UI update
+        int currentCount = originalPost.getLikeCount();
+        if (liked) {
+            originalPost.setLikeCount(Math.max(0, currentCount - 1));
+            originalPost.getLikedBy().remove(userId);
+        } else {
+            originalPost.setLikeCount(currentCount + 1);
+            originalPost.getLikedBy().put(userId, true);
+        }
+        bindPostToLayout(originalPost);
 
         if (liked) {
             db.collection("forumThreads").document(postId)
                     .update("likeCount", FieldValue.increment(-1),
-                            "likedBy." + userId, FieldValue.delete());
+                            "likedBy." + userId, FieldValue.delete())
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        originalPost.setLikeCount(currentCount);
+                        originalPost.getLikedBy().put(userId, true);
+                        bindPostToLayout(originalPost);
+                    });
         } else {
             db.collection("forumThreads").document(postId)
                     .update("likeCount", FieldValue.increment(1),
-                            "likedBy." + userId, true);
+                            "likedBy." + userId, true)
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        originalPost.setLikeCount(currentCount);
+                        originalPost.getLikedBy().remove(userId);
+                        bindPostToLayout(originalPost);
+                    });
         }
     }
 
@@ -613,16 +646,40 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
         if (user == null) return;
 
         String userId = user.getUid();
-        boolean liked = comment.getLikedBy() != null && comment.getLikedBy().containsKey(userId);
+        if (comment.getLikedBy() == null) comment.setLikedBy(new HashMap<>());
+        boolean liked = comment.getLikedBy().containsKey(userId);
+
+        // Optimistic UI update
+        int currentCount = comment.getLikeCount();
+        if (liked) {
+            comment.setLikeCount(Math.max(0, currentCount - 1));
+            comment.getLikedBy().remove(userId);
+        } else {
+            comment.setLikeCount(currentCount + 1);
+            comment.getLikedBy().put(userId, true);
+        }
+        adapter.notifyDataSetChanged();
 
         if (liked) {
             db.collection("forumThreads").document(postId).collection("comments").document(comment.getId())
                     .update("likeCount", FieldValue.increment(-1),
-                            "likedBy." + userId, FieldValue.delete());
+                            "likedBy." + userId, FieldValue.delete())
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        comment.setLikeCount(currentCount);
+                        comment.getLikedBy().put(userId, true);
+                        adapter.notifyDataSetChanged();
+                    });
         } else {
             db.collection("forumThreads").document(postId).collection("comments").document(comment.getId())
                     .update("likeCount", FieldValue.increment(1),
-                            "likedBy." + userId, true);
+                            "likedBy." + userId, true)
+                    .addOnFailureListener(e -> {
+                        // Revert on failure
+                        comment.setLikeCount(currentCount);
+                        comment.getLikedBy().remove(userId);
+                        adapter.notifyDataSetChanged();
+                    });
         }
     }
 

--- a/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
+++ b/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
@@ -31,6 +31,7 @@ import com.google.firebase.firestore.Query;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class UserSocialProfileActivity extends AppCompatActivity implements 
@@ -375,13 +376,41 @@ public class UserSocialProfileActivity extends AppCompatActivity implements
     @Override public void onLikeClick(ForumPost post) {
         Log.d(TAG, "Post Liked: " + post.getId());
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-        if (user == null) return;
+        if (user == null || post.getId() == null) return;
+        
         String userId = user.getUid();
-        boolean currentlyLiked = post.getLikedBy() != null && post.getLikedBy().containsKey(userId);
+        if (post.getLikedBy() == null) post.setLikedBy(new HashMap<>());
+        boolean currentlyLiked = post.getLikedBy().containsKey(userId);
+        
+        // Optimistic UI update
+        int currentCount = post.getLikeCount();
         if (currentlyLiked) {
-            db.collection("forumThreads").document(post.getId()).update("likeCount", FieldValue.increment(-1), "likedBy." + userId, FieldValue.delete());
+            post.setLikeCount(Math.max(0, currentCount - 1));
+            post.getLikedBy().remove(userId);
         } else {
-            db.collection("forumThreads").document(post.getId()).update("likeCount", FieldValue.increment(1), "likedBy." + userId, true);
+            post.setLikeCount(currentCount + 1);
+            post.getLikedBy().put(userId, true);
+        }
+        adapter.notifyDataSetChanged();
+
+        if (currentlyLiked) {
+            db.collection("forumThreads").document(post.getId())
+                    .update("likeCount", FieldValue.increment(-1), "likedBy." + userId, FieldValue.delete())
+                    .addOnFailureListener(e -> {
+                        // Revert
+                        post.setLikeCount(currentCount);
+                        post.getLikedBy().put(userId, true);
+                        adapter.notifyDataSetChanged();
+                    });
+        } else {
+            db.collection("forumThreads").document(post.getId())
+                    .update("likeCount", FieldValue.increment(1), "likedBy." + userId, true)
+                    .addOnFailureListener(e -> {
+                        // Revert
+                        post.setLikeCount(currentCount);
+                        post.getLikedBy().remove(userId);
+                        adapter.notifyDataSetChanged();
+                    });
         }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -50,20 +50,22 @@ service cloud.firestore {
     }
 
     // --- Forum Collection ---
-    match /forumThreads/{postId} {
-      allow read: if isSignedIn();
-      allow create: if isSignedIn() && request.resource.data.userId == request.auth.uid;
-      allow update, delete: if isSignedIn() && resource.data.userId == request.auth.uid;
-      allow update: if isSignedIn() && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likeCount', 'likedBy']);
+        match /forumThreads/{postId} {
+          allow read: if isSignedIn();
+          allow create: if isSignedIn() && request.resource.data.userId == request.auth.uid;
+          allow update, delete: if isSignedIn() && resource.data.userId == request.auth.uid;
+          // Allow non-owners to update stats and view tracking
+          allow update: if isSignedIn() && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likeCount', 'likedBy', 'viewCount', 'viewedBy', 'commentCount']);
 
-      match /comments/{commentId} {
-        allow read: if isSignedIn();
-        allow create: if isSignedIn() && request.resource.data.userId == request.auth.uid;
-        // Allow deletion if the user owns the comment OR if they own the parent thread
-        allow delete: if isSignedIn() && (resource.data.userId == request.auth.uid || get(/databases/$(database)/documents/forumThreads/$(postId)).data.userId == request.auth.uid);
-        allow update: if isSignedIn() && (resource.data.userId == request.auth.uid || request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likeCount', 'likedBy']));
-      }
-    }
+          match /comments/{commentId} {
+            allow read: if isSignedIn();
+            allow create: if isSignedIn() && request.resource.data.userId == request.auth.uid;
+            // Allow deletion if the user owns the comment OR if they own the parent thread
+            allow delete: if isSignedIn() && (resource.data.userId == request.auth.uid || get(/databases/$(database)/documents/forumThreads/$(postId)).data.userId == request.auth.uid);
+            // Allow non-owners to update like status
+            allow update: if isSignedIn() && (resource.data.userId == request.auth.uid || request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likeCount', 'likedBy']));
+          }
+        }
 
     // --- Backlog Collection for Deletions ---
     match /deletedforum_backlog/{docId} {


### PR DESCRIPTION
Implemented optimistic UI updates for liking forum posts and comments across multiple activities, including `UserSocialProfileActivity`, `NearbyHeatmapActivity`, and `PostDetailActivity`. This change ensures immediate visual feedback when users interact with the like button while handling server-side synchronization and failure reverts.

Additionally, updated `ForumCommentAdapter` and `ForumPostAdapter` to correctly reflect the user's like status with appropriate heart icons and modified `firestore.rules` to allow non-owners to update `viewCount`, `viewedBy`, and `commentCount` on forum threads.