### PR TITLE
like count synchronization for forum comments and replies.

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumComment.java
+++ b/app/src/main/java/com/birddex/app/ForumComment.java
@@ -23,6 +23,7 @@ public class ForumComment {
 
     public ForumComment() {
         // Required for Firestore
+        this.likedBy = new java.util.HashMap<>();
     }
 
     public ForumComment(String threadId, String userId, String username, String userProfilePictureUrl, String text) {
@@ -32,6 +33,7 @@ public class ForumComment {
         this.userProfilePictureUrl = userProfilePictureUrl;
         this.text = text;
         this.likeCount = 0;
+        this.likedBy = new java.util.HashMap<>();
         this.edited = false;
         this.likeNotificationSent = false;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -119,7 +119,7 @@ service cloud.firestore {
         allow update: if isSignedIn() && (
           isOwnerOfResource() ||
           request.resource.data.diff(resource.data).affectedKeys()
-            .hasOnly(['likeCount', 'likedBy'])
+            .hasOnly(['likedBy'])
         );
       }
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -1659,6 +1659,22 @@ exports.onForumThreadEngagementUpdated = onDocumentUpdated("forumThreads/{thread
     return null;
 });
 
+exports.onCommentEngagementUpdated = onDocumentUpdated("forumThreads/{threadId}/comments/{commentId}", async (event) => {
+    const afterData = event.data.after.data();
+    if (!afterData) {
+        logger.info(`Comment engagement updated but no after data for ${event.params.commentId}`);
+        return null;
+    }
+    const likedByAfter = afterData.likedBy || {};
+    const newLikeCount = Object.keys(likedByAfter).length;
+    const currentLikeCount = afterData.likeCount || 0;
+    if (newLikeCount !== currentLikeCount) {
+        logger.info(`Recalculating likes for comment ${event.params.commentId} in thread ${event.params.threadId}: New count = ${newLikeCount}`);
+        await event.data.after.ref.update({ likeCount: newLikeCount });
+    }
+    return null;
+});
+
 // ======================================================
 // onCommentCreated — notify on reply or post activity + IDEMPOTENT COUNT
 // ======================================================


### PR DESCRIPTION
- Added `onCommentEngagementUpdated` Cloud Function to automatically recalculate and update `likeCount` based on the `likedBy` map size.
- Updated `firestore.rules` to restrict manual client-side updates of `likeCount`, allowing clients to only modify `likedBy`.
- Modified `ForumComment` model to initialize the `likedBy` map in all constructors to prevent null pointer issues.