### PR TITLE
Updated the forum posting logic to restrict daily limits only to post…

### DIFF
--- a/app/src/main/java/com/birddex/app/CreatePostActivity.java
+++ b/app/src/main/java/com/birddex/app/CreatePostActivity.java
@@ -377,7 +377,8 @@ public class CreatePostActivity extends AppCompatActivity {
         //   (a) We don't waste Storage on a post that will be rejected.
         //   (b) The limit is enforced atomically — two rapid taps cannot both slip through
         //       because the CF uses a Firestore transaction to read+increment in one step.
-        checkServerPostLimit(msg);
+        boolean wantsToShowLocation = binding.swShowLocation.isChecked();
+        checkServerPostLimit(msg, wantsToShowLocation);
     }
 
     /**
@@ -393,12 +394,18 @@ public class CreatePostActivity extends AppCompatActivity {
      * User-facing feedback is shown here so the user knows whether the action succeeded, failed,
      * or needs attention.
      */
-    private void checkServerPostLimit(String msg) {
-        // Set up or query the Firebase layer that supplies/stores this feature's data.
-        firebaseManager.recordForumPost(new FirebaseManager.ForumPostLimitListener() {
-            @Override public void onAllowed(int remaining) {
+    /**
+     * Calls recordForumPost CF.
+     * The backend only applies the 3-per-day limit when showLocation == true.
+     * Normal posts without map location are always allowed through.
+     */
+    private void checkServerPostLimit(String msg, boolean wantsToShowLocation) {
+        firebaseManager.recordForumPost(wantsToShowLocation, new FirebaseManager.ForumPostLimitListener() {
+            @Override
+            public void onAllowed(int remaining) {
                 if (isFinishing() || isDestroyed()) return;
-                // Slot claimed — proceed with upload or direct Firestore write
+
+                // Proceed normally once the backend says this post is allowed.
                 if (viewModel.getUploadedImageUrl() != null) {
                     createFirestorePost(msg, viewModel.getUploadedImageUrl());
                 } else if (selectedImageUri != null) {
@@ -407,24 +414,34 @@ public class CreatePostActivity extends AppCompatActivity {
                     createFirestorePost(msg, null);
                 }
             }
-            @Override public void onLimitReached() {
+
+            @Override
+            public void onLimitReached() {
                 if (isFinishing() || isDestroyed()) return;
-                // Persist the new state so the action is saved outside the current screen.
+
                 viewModel.isPostInProgress.set(false);
                 setPostingUi(false);
-                // Give the user immediate feedback about the result of this action.
-                Toast.makeText(CreatePostActivity.this,
-                        "You've reached your 3 post limit for today. Try again tomorrow!",
-                        Toast.LENGTH_LONG).show();
+
+                Toast.makeText(
+                        CreatePostActivity.this,
+                        "You can only post with map location 3 times per day.",
+                        Toast.LENGTH_LONG
+                ).show();
             }
-            @Override public void onFailure(String errorMessage) {
+
+            @Override
+            public void onFailure(String errorMessage) {
                 if (isFinishing() || isDestroyed()) return;
+
                 Log.e(TAG, "recordForumPost failed: " + errorMessage);
                 viewModel.isPostInProgress.set(false);
                 setPostingUi(false);
-                Toast.makeText(CreatePostActivity.this,
-                        "Could not verify post limit. Please try again.",
-                        Toast.LENGTH_SHORT).show();
+
+                Toast.makeText(
+                        CreatePostActivity.this,
+                        "Could not verify posting limit. Please try again.",
+                        Toast.LENGTH_SHORT
+                ).show();
             }
         });
     }

--- a/app/src/main/java/com/birddex/app/FirebaseManager.java
+++ b/app/src/main/java/com/birddex/app/FirebaseManager.java
@@ -2,7 +2,6 @@ package com.birddex.app;
 
 import android.content.Context;
 import android.util.Log;
-import android.widget.Toast;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
@@ -12,17 +11,14 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.EventListener;
-import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.SetOptions;
-import com.google.firebase.firestore.WriteBatch;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
 import com.google.firebase.functions.HttpsCallableResult;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -585,27 +581,37 @@ public class FirebaseManager {
     /**
      * Main logic block for this part of the feature.
      */
-    public void recordForumPost(ForumPostLimitListener listener) {
-        Log.d(TAG, "Calling recordForumPost CF.");
-        mFunctions.getHttpsCallable("recordForumPost").call().addOnCompleteListener(task -> {
-            if (task.isSuccessful() && task.getResult() != null) {
-                Map<String, Object> res = (Map<String, Object>) task.getResult().getData();
-                boolean allowed = res != null && Boolean.TRUE.equals(res.get("allowed"));
-                if (allowed) {
-                    int remaining = res.get("remaining") != null
-                            ? ((Number) res.get("remaining")).intValue() : 0;
-                    Log.d(TAG, "recordForumPost: allowed, remaining=" + remaining);
-                    listener.onAllowed(remaining);
-                } else {
-                    Log.d(TAG, "recordForumPost: daily limit reached.");
-                    listener.onLimitReached();
-                }
-            } else {
-                String error = task.getException() != null ? task.getException().getMessage() : "recordForumPost failed.";
-                Log.e(TAG, "recordForumPost CF failed: " + error);
-                listener.onFailure(error);
-            }
-        });
+    public void recordForumPost(boolean showLocation, ForumPostLimitListener listener) {
+        Log.d(TAG, "Calling recordForumPost CF. showLocation=" + showLocation);
+
+        java.util.Map<String, Object> data = new java.util.HashMap<>();
+        data.put("showLocation", showLocation);
+
+        mFunctions.getHttpsCallable("recordForumPost")
+                .call(data)
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful() && task.getResult() != null) {
+                        Map<String, Object> res = (Map<String, Object>) task.getResult().getData();
+                        boolean allowed = res != null && Boolean.TRUE.equals(res.get("allowed"));
+
+                        if (allowed) {
+                            int remaining = res.get("remaining") != null
+                                    ? ((Number) res.get("remaining")).intValue()
+                                    : 0;
+                            Log.d(TAG, "recordForumPost: allowed, remaining=" + remaining);
+                            listener.onAllowed(remaining);
+                        } else {
+                            Log.d(TAG, "recordForumPost: location-post daily limit reached.");
+                            listener.onLimitReached();
+                        }
+                    } else {
+                        String error = task.getException() != null
+                                ? task.getException().getMessage()
+                                : "recordForumPost failed.";
+                        Log.e(TAG, "recordForumPost CF failed: " + error);
+                        listener.onFailure(error);
+                    }
+                });
     }
 
     // -------------------------------------------------------------------------

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,13 @@ service cloud.firestore {
       return request.auth != null && request.resource.data.userId == request.auth.uid;
     }
 
+    function onlySessionFieldUpdate() {
+  		return request.resource.data.diff(resource.data).affectedKeys()
+    	.hasOnly(['currentSessionId']) &&
+    	request.resource.data.currentSessionId is string &&
+    	request.resource.data.currentSessionId.size() > 0;
+		}
+
     // Fields that only Cloud Functions should ever write.
     // If any of these are in the incoming diff, block the client write.
     function onlyClientProfileFields() {
@@ -39,7 +46,10 @@ service cloud.firestore {
       allow read: if isSignedIn();
 
       // Owner can update their own profile, but cannot touch CF-managed fields
-      allow update: if isOwner(userId) && onlyClientProfileFields();
+      allow update: if isOwner(userId) && (
+  			onlyClientProfileFields() ||
+  			onlySessionFieldUpdate()
+				);
 
       // Creation/deletion handled by Cloud Functions only
       allow create, delete: if false;
@@ -88,41 +98,54 @@ service cloud.firestore {
       allow write: if false; // Cloud Functions (initializeUser) only
     }
 
-    // --- Forum Collection ---
-    match /forumThreads/{postId} {
-      allow read: if isSignedIn();
+  	match /forumThreads/{postId} {
+  		allow read: if isSignedIn();
 
-      // Only create if the userId field matches the requester
-      allow create: if isSignedIn() && incomingDataOwned();
+  	// Only create if the userId field matches the requester
+  		allow create: if isSignedIn() && incomingDataOwned();
 
-      // Owner can update/delete their thread.
-      // Any signed-in user can update ONLY the engagement stat fields.
-      allow update: if isSignedIn() && (
-        isOwnerOfResource() ||
-        request.resource.data.diff(resource.data).affectedKeys()
-          .hasOnly(['likeCount', 'likedBy', 'viewCount', 'viewedBy', 'commentCount'])
-      );
-      allow delete: if isSignedIn() && isOwnerOfResource();
+  		allow update: if isSignedIn() && (
+    // Owner can edit for 5 minutes, but NOT location/map fields
+    (
+      isOwnerOfResource() &&
+      resource.data.createdAt != null &&
+      request.time < resource.data.createdAt + duration.value(5, "m") &&
+      !request.resource.data.diff(resource.data).affectedKeys().hasAny([
+        'showLocation',
+        'latitude',
+        'longitude',
+        'locationId',
+        'localityName',
+        'state',
+        'country',
+        'userId',
+        'createdAt'
+      ])
+    ) ||
+    // Other signed-in users can only update engagement fields
+    request.resource.data.diff(resource.data).affectedKeys()
+      .hasOnly(['likeCount', 'likedBy', 'viewCount', 'viewedBy', 'commentCount'])
+  	);
 
-      match /comments/{commentId} {
-        allow read: if isSignedIn();
+  			allow delete: if isSignedIn() && isOwnerOfResource();
 
-        allow create: if isSignedIn() && incomingDataOwned();
+  		match /comments/{commentId} {
+    	allow read: if isSignedIn();
 
-        // Owner of comment or owner of parent thread can delete
-        allow delete: if isSignedIn() && (
-          isOwnerOfResource() ||
-          get(/databases/$(database)/documents/forumThreads/$(postId)).data.userId == request.auth.uid
-        );
+    		allow create: if isSignedIn() && incomingDataOwned();
 
-        // Comment owner can update freely; others can only update like fields
-        allow update: if isSignedIn() && (
-          isOwnerOfResource() ||
-          request.resource.data.diff(resource.data).affectedKeys()
-            .hasOnly(['likedBy'])
-        );
-      }
-    }
+    		allow delete: if isSignedIn() && (
+      	isOwnerOfResource() ||
+      	get(/databases/$(database)/documents/forumThreads/$(postId)).data.userId == request.auth.uid
+    		);
+
+    		allow update: if isSignedIn() && (
+      	isOwnerOfResource() ||
+      	request.resource.data.diff(resource.data).affectedKeys()
+        .hasOnly(['likedBy'])
+    		);
+  		}
+		}
 
     // --- Backlog Collection for Deletions ---
     match /deletedforum_backlog/{docId} {

--- a/functions/index.js
+++ b/functions/index.js
@@ -2814,17 +2814,37 @@ exports.recordBirdSighting = onCall(async (request) => {
  * Input/permission checks happen here first so invalid requests fail before any expensive
  * backend work starts.
  */
+// ======================================================
+// recordForumPost — only limit posts that SHOW LOCATION ON MAP
+// ======================================================
+// If showLocation == false:
+//   - allow the post immediately
+//   - do NOT consume one of the 3 daily map-location post slots
+//
+// If showLocation == true:
+//   - enforce the 3-per-day limit
+//   - atomically increment the user's daily map-location post count
+// ======================================================
 exports.recordForumPost = onCall(async (request) => {
     if (!request.auth) throw new HttpsError("unauthenticated", "Login required.");
 
     const userId = request.auth.uid;
-    const MAX_DAILY_POSTS = 3;
+    const { showLocation = false } = request.data || {};
+    const MAX_DAILY_LOCATION_POSTS = 3;
 
-    // Use UTC date string as the key so it resets at midnight UTC
-    const today = new Date().toISOString().slice(0, 10); // e.g. "2026-03-08"
+    // If the user is posting WITHOUT location, do not apply the daily limit at all.
+    if (!showLocation) {
+        return {
+            allowed: true,
+            remaining: MAX_DAILY_LOCATION_POSTS,
+            locationLimited: false
+        };
+    }
+
+    // Use UTC date key so the count resets each day.
+    const today = new Date().toISOString().slice(0, 10);
 
     const postLimitRef = db
-        // This is where the function touches Firestore documents/collections for the requested action.
         .collection("users").doc(userId)
         .collection("settings").doc("forumPostLimits");
 
@@ -2832,30 +2852,49 @@ exports.recordForumPost = onCall(async (request) => {
         const result = await db.runTransaction(async (t) => {
             const snap = await t.get(postLimitRef);
 
-            let postsToday = 0;
+            let locationPostsToday = 0;
+
             if (snap.exists) {
                 const data = snap.data();
-                // Reset if the stored date is not today
+
+                // Only reuse the stored count if it is from today.
                 if (data.date === today) {
-                    postsToday = typeof data.postsToday === "number" ? data.postsToday : 0;
+                    locationPostsToday =
+                        typeof data.locationPostsToday === "number"
+                            ? data.locationPostsToday
+                            : 0;
                 }
             }
 
-            if (postsToday >= MAX_DAILY_POSTS) {
-                return { allowed: false, remaining: 0 };
+            // If the user already used all 3 location-post slots today, reject.
+            if (locationPostsToday >= MAX_DAILY_LOCATION_POSTS) {
+                return {
+                    allowed: false,
+                    remaining: 0,
+                    locationLimited: true
+                };
             }
 
-            const newCount = postsToday + 1;
+            const newCount = locationPostsToday + 1;
+
+            // Save the updated daily count for location-sharing forum posts only.
             t.set(postLimitRef, {
                 date: today,
-                postsToday: newCount,
+                locationPostsToday: newCount,
                 updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-            });
+            }, { merge: true });
 
-            return { allowed: true, remaining: MAX_DAILY_POSTS - newCount };
+            return {
+                allowed: true,
+                remaining: MAX_DAILY_LOCATION_POSTS - newCount,
+                locationLimited: true
+            };
         });
 
-        logger.info(`recordForumPost: userId=${userId} allowed=${result.allowed} remaining=${result.remaining}`);
+        logger.info(
+            `recordForumPost: userId=${userId} showLocation=${showLocation} allowed=${result.allowed} remaining=${result.remaining}`
+        );
+
         return result;
 
     } catch (error) {


### PR DESCRIPTION
…s that include location data and refined Firestore security rules.

- **Forum Post Rate Limiting**:
    - Modified `recordForumPost` Cloud Function to only enforce the 3-post-per-day limit when `showLocation` is enabled.
    - Updated `FirebaseManager` and `CreatePostActivity` to pass the `showLocation` state to the server-side validation.
    - Updated backend storage to use `locationPostsToday` to specifically track map-enabled posts.

- **Firestore Security Rules**:
    - Implemented a 5-minute edit window for forum post owners, explicitly blocking modifications to sensitive location and metadata fields (`latitude`, `longitude`, `localityName`, `userId`, etc.).
    - Added `onlySessionFieldUpdate` rule to allow specific updates to `currentSessionId` while maintaining profile field restrictions.
    - Standardized indentation and nesting for `forumThreads` and `comments` collections.

- **Client-Side Enhancements**:
    - Updated UI feedback in `CreatePostActivity` to clarify that the daily limit specifically applies to posts with map locations.
    - Cleaned up unused imports and added `merge: true` to Firestore transactions in Cloud Functions for better data persistence.