### PR TITLE
Implemented forum submission cooldown to prevent rapid-fire posts and…

### DIFF
--- a/app/src/main/java/com/birddex/app/CreatePostActivity.java
+++ b/app/src/main/java/com/birddex/app/CreatePostActivity.java
@@ -369,6 +369,10 @@ public class CreatePostActivity extends AppCompatActivity {
             Toast.makeText(this, "Inappropriate language detected.", Toast.LENGTH_LONG).show();
             return;
         }
+        if (ForumSubmissionCooldownHelper.isCoolingDown(this)) {
+            Toast.makeText(this, ForumSubmissionCooldownHelper.buildCooldownMessage(this), Toast.LENGTH_SHORT).show();
+            return;
+        }
 
         // Persist the new state so the action is saved outside the current screen.
         viewModel.isPostInProgress.set(true);
@@ -441,7 +445,9 @@ public class CreatePostActivity extends AppCompatActivity {
 
                 Toast.makeText(
                         CreatePostActivity.this,
-                        "Could not verify posting limit. Please try again.",
+                        errorMessage != null && !errorMessage.trim().isEmpty()
+                                ? errorMessage
+                                : "Could not verify posting limit. Please try again.",
                         Toast.LENGTH_SHORT
                 ).show();
             }
@@ -508,6 +514,7 @@ public class CreatePostActivity extends AppCompatActivity {
             @Override
             public void onSuccess() {
                 if (isFinishing() || isDestroyed()) return;
+                ForumSubmissionCooldownHelper.markSubmissionSuccess(CreatePostActivity.this);
                 // Persist the new state so the action is saved outside the current screen.
                 viewModel.isPostFinished.set(true);
                 viewModel.isPostInProgress.set(false);

--- a/app/src/main/java/com/birddex/app/ForumSubmissionCooldownHelper.java
+++ b/app/src/main/java/com/birddex/app/ForumSubmissionCooldownHelper.java
@@ -1,0 +1,46 @@
+package com.birddex.app;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Shared forum submission cooldown helper.
+ *
+ * The backend is still the final authority, but this gives the user instant feedback and prevents
+ * obvious rapid re-taps from the current device before the callable runs.
+ */
+public final class ForumSubmissionCooldownHelper {
+
+    private static final String PREFS_NAME = "BirdDexPrefs";
+    private static final String KEY_LAST_FORUM_SUBMISSION_MS = "last_forum_submission_ms";
+    public static final long FORUM_SUBMISSION_COOLDOWN_MS = 15_000L;
+
+    private ForumSubmissionCooldownHelper() {
+        // Utility class.
+    }
+
+    public static long getRemainingCooldownMs(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        long lastSubmissionMs = prefs.getLong(KEY_LAST_FORUM_SUBMISSION_MS, 0L);
+        long elapsedMs = System.currentTimeMillis() - lastSubmissionMs;
+        long remainingMs = FORUM_SUBMISSION_COOLDOWN_MS - elapsedMs;
+        return Math.max(0L, remainingMs);
+    }
+
+    public static boolean isCoolingDown(Context context) {
+        return getRemainingCooldownMs(context) > 0L;
+    }
+
+    public static void markSubmissionSuccess(Context context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putLong(KEY_LAST_FORUM_SUBMISSION_MS, System.currentTimeMillis())
+                .apply();
+    }
+
+    public static String buildCooldownMessage(Context context) {
+        long remainingMs = getRemainingCooldownMs(context);
+        long remainingSeconds = Math.max(1L, (long) Math.ceil(remainingMs / 1000.0));
+        return "Please wait " + remainingSeconds + " second" + (remainingSeconds == 1L ? "" : "s") + " before submitting again.";
+    }
+}

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -457,6 +457,10 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         View sendCommentButton = view.findViewById(R.id.btnSendComment);
         sendCommentButton.setOnClickListener(v -> {
             String text = currentPopupEditText.getText().toString().trim(); if (text.isEmpty() || user == null || ContentFilter.containsInappropriateContent(text)) return;
+            if (ForumSubmissionCooldownHelper.isCoolingDown(this)) {
+                Toast.makeText(this, ForumSubmissionCooldownHelper.buildCooldownMessage(this), Toast.LENGTH_SHORT).show();
+                return;
+            }
             sendCommentButton.setEnabled(false);
 
             String commentId = db.collection("forumThreads").document(p.getId()).collection("comments").document().getId();
@@ -465,6 +469,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             firebaseManager.createForumComment(p.getId(), commentId, text, parentCommentId, new FirebaseManager.ForumWriteListener() {
                 @Override public void onSuccess() {
                     if (isFinishing() || isDestroyed()) return;
+                    ForumSubmissionCooldownHelper.markSubmissionSuccess(NearbyHeatmapActivity.this);
                     currentPopupEditText.setText("");
                     currentPopupEditText.setHint("Write a comment...");
                     replyingToComment = null;

--- a/app/src/main/java/com/birddex/app/PostDetailActivity.java
+++ b/app/src/main/java/com/birddex/app/PostDetailActivity.java
@@ -525,6 +525,10 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
     private void postComment() {
         String msg = binding.etComment.getText().toString().trim();
         if (msg.isEmpty() || msg.length() > MAX_COMMENT_LENGTH || !ContentFilter.isSafe(this, msg, "Comment")) return;
+        if (ForumSubmissionCooldownHelper.isCoolingDown(this)) {
+            Toast.makeText(this, ForumSubmissionCooldownHelper.buildCooldownMessage(this), Toast.LENGTH_SHORT).show();
+            return;
+        }
         FirebaseUser user = mAuth.getCurrentUser(); if (user == null) return;
         binding.btnSendComment.setEnabled(false);
 
@@ -535,6 +539,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
             @Override
             public void onSuccess() {
                 if (isFinishing()) return;
+                ForumSubmissionCooldownHelper.markSubmissionSuccess(PostDetailActivity.this);
                 binding.etComment.setText("");
                 binding.etComment.setHint("Write a comment...");
                 replyingToComment = null;

--- a/functions/index.js
+++ b/functions/index.js
@@ -2847,11 +2847,15 @@ exports.recordForumPost = onCall(async (request) => {
 
     // If the user is posting WITHOUT location, do not apply the daily limit at all.
     if (!showLocation) {
-        return {
-            allowed: true,
-            remaining: MAX_DAILY_LOCATION_POSTS,
-            locationLimited: false
-        };
+        const result = await db.runTransaction(async (t) => {
+            await assertForumSubmissionCooldownAllowed(t, userId, "post");
+            return {
+                allowed: true,
+                remaining: MAX_DAILY_LOCATION_POSTS,
+                locationLimited: false
+            };
+        });
+        return result;
     }
 
     // Use UTC date key so the count resets each day.
@@ -2863,6 +2867,7 @@ exports.recordForumPost = onCall(async (request) => {
 
     try {
         const result = await db.runTransaction(async (t) => {
+            await assertForumSubmissionCooldownAllowed(t, userId, "post");
             const snap = await t.get(postLimitRef);
 
             let locationPostsToday = 0;
@@ -2923,6 +2928,7 @@ exports.recordForumPost = onCall(async (request) => {
 const FORUM_POST_MAX_LENGTH = 500;
 const FORUM_COMMENT_MAX_LENGTH = 300;
 const FORUM_EDIT_WINDOW_MS = 5 * 60 * 1000;
+const FORUM_SUBMISSION_COOLDOWN_MS = 15 * 1000;
 
 /**
  * Reads the caller's canonical forum identity from users/{uid} so the client cannot spoof it.
@@ -2992,6 +2998,64 @@ function assertWithinForumEditWindow(timestamp, typeLabel) {
     }
 }
 
+
+
+/**
+ * Returns the user-scoped forum cooldown document ref.
+ */
+function getForumSubmissionCooldownRef(userId) {
+    return db.collection("users").doc(userId).collection("settings").doc("forumSubmissionCooldown");
+}
+
+
+/**
+ * Throws a user-facing cooldown error when the previous forum submission is still too recent.
+ */
+function maybeThrowForumSubmissionCooldownError(lastSubmissionAt, submissionType) {
+    const lastSubmissionMs = lastSubmissionAt && typeof lastSubmissionAt.toMillis === "function"
+        ? lastSubmissionAt.toMillis()
+        : null;
+
+    if (lastSubmissionMs == null) {
+        return;
+    }
+
+    const elapsedMs = admin.firestore.Timestamp.now().toMillis() - lastSubmissionMs;
+    if (elapsedMs < FORUM_SUBMISSION_COOLDOWN_MS) {
+        const remainingMs = FORUM_SUBMISSION_COOLDOWN_MS - elapsedMs;
+        const remainingSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
+        throw new HttpsError(
+            "resource-exhausted",
+            `Please wait ${remainingSeconds} second${remainingSeconds === 1 ? "" : "s"} before submitting another forum ${submissionType}.`
+        );
+    }
+}
+
+/**
+ * Checks whether the user is still inside the forum submission cooldown without consuming it.
+ */
+async function assertForumSubmissionCooldownAllowed(transaction, userId, submissionType) {
+    const cooldownSnap = await transaction.get(getForumSubmissionCooldownRef(userId));
+    if (!cooldownSnap.exists) {
+        return;
+    }
+    maybeThrowForumSubmissionCooldownError(cooldownSnap.get("lastSubmissionAt"), submissionType);
+}
+
+/**
+ * Enforces the forum submission cooldown and records the new submit timestamp inside the same transaction.
+ */
+async function assertAndConsumeForumSubmissionCooldown(transaction, userId, submissionType) {
+    const cooldownRef = getForumSubmissionCooldownRef(userId);
+    await assertForumSubmissionCooldownAllowed(transaction, userId, submissionType);
+    const nowTs = admin.firestore.Timestamp.now();
+
+    transaction.set(cooldownRef, {
+        lastSubmissionAt: nowTs,
+        lastSubmissionType: submissionType,
+        updatedAt: nowTs,
+    }, { merge: true });
+}
 
 /**
  * Converts a Firebase Storage download URL back into the storage object path.
@@ -3110,6 +3174,8 @@ exports.createForumPost = onCall(async (request) => {
                 throw new HttpsError("already-exists", "That post already exists.");
             }
 
+            await assertAndConsumeForumSubmissionCooldown(t, userId, "post");
+
             const postData = {
                 userId,
                 username,
@@ -3185,6 +3251,8 @@ exports.createForumComment = onCall(async (request) => {
             if (existingCommentSnap.exists) {
                 throw new HttpsError("already-exists", "That comment already exists.");
             }
+
+            await assertAndConsumeForumSubmissionCooldown(t, userId, parentCommentId ? "reply" : "comment");
 
             let normalizedParentCommentId = null;
             let parentUsername = null;


### PR DESCRIPTION
… comments.

- **Backend (Cloud Functions)**:
    - Introduced a 15-second cooldown (`FORUM_SUBMISSION_COOLDOWN_MS`) for forum posts, comments, and replies.
    - Implemented `assertAndConsumeForumSubmissionCooldown` to enforce rate-limiting via a new `forumSubmissionCooldown` document per user within Firestore transactions.
    - Updated `checkForumPostLimit` and `createForumComment` to validate and update the cooldown state.

- **Frontend (Android)**:
    - Added `ForumSubmissionCooldownHelper` to provide client-side validation and immediate user feedback using `SharedPreferences`.
    - Integrated cooldown checks and success marking in `CreatePostActivity`, `PostDetailActivity`, and `NearbyHeatmapActivity`.
    - Improved error handling in `CreatePostActivity` to display specific backend error messages to the user.