### PR TITLE
Implemented forum post saving functionality and tightened Firestore s…

### DIFF
--- a/app/src/main/java/com/birddex/app/FirebaseManager.java
+++ b/app/src/main/java/com/birddex/app/FirebaseManager.java
@@ -855,6 +855,83 @@ public class FirebaseManager {
         });
     }
 
+    /**
+     * Saves a forum post for the current user through the backend so the saved timestamp is canonical
+     * and duplicate entries are prevented server-side.
+     */
+    public void saveForumPost(String postId, ForumWriteListener listener) {
+        Log.d(TAG, "Calling saveForumPost CF for post: " + postId);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("threadId", postId);
+
+        mFunctions.getHttpsCallable("saveForumPost").call(data).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                Log.d(TAG, "saveForumPost CF succeeded.");
+                if (listener != null) listener.onSuccess();
+            } else {
+                String error = getCallableErrorMessage(task, "Failed to save post.");
+                Log.e(TAG, "saveForumPost CF failed: " + error);
+                if (listener != null) listener.onFailure(error);
+            }
+        });
+    }
+
+    /**
+     * Removes a saved forum post entry for the current user through the backend.
+     */
+    public void unsaveForumPost(String postId, ForumWriteListener listener) {
+        Log.d(TAG, "Calling unsaveForumPost CF for post: " + postId);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("threadId", postId);
+
+        mFunctions.getHttpsCallable("unsaveForumPost").call(data).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                Log.d(TAG, "unsaveForumPost CF succeeded.");
+                if (listener != null) listener.onSuccess();
+            } else {
+                String error = getCallableErrorMessage(task, "Failed to unsave post.");
+                Log.e(TAG, "unsaveForumPost CF failed: " + error);
+                if (listener != null) listener.onFailure(error);
+            }
+        });
+    }
+
+    /**
+     * Reads whether the current user has already saved a forum post through the backend so the
+     * Save/Unsave label does not depend on client Firestore read rules.
+     */
+    public void isForumPostSaved(String postId, OnCompleteListener<Boolean> listener) {
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user == null) {
+            if (listener != null) listener.onComplete(Tasks.forResult(false));
+            return;
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("threadId", postId);
+
+        mFunctions.getHttpsCallable("getForumPostSaveState").call(data).addOnCompleteListener(task -> {
+            if (listener == null) return;
+
+            if (task.isSuccessful() && task.getResult() != null) {
+                Object raw = task.getResult().getData();
+                boolean isSaved = false;
+
+                if (raw instanceof Map) {
+                    Object saved = ((Map<?, ?>) raw).get("saved");
+                    isSaved = Boolean.TRUE.equals(saved);
+                }
+
+                listener.onComplete(Tasks.forResult(isSaved));
+            } else {
+                String error = getCallableErrorMessage(task, "Failed to check saved post state.");
+                listener.onComplete(Tasks.forException(new Exception(error)));
+            }
+        });
+    }
+
     // -------------------------------------------------------------------------
     // BIRD & SIGHTING METHODS
     // -------------------------------------------------------------------------

--- a/app/src/main/java/com/birddex/app/ForumFragment.java
+++ b/app/src/main/java/com/birddex/app/ForumFragment.java
@@ -349,15 +349,57 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
     }
 
     @Override public void onOptionsClick(ForumPost p, View v) {
-        PopupMenu popup = new PopupMenu(getContext(), v); FirebaseUser u = mAuth.getCurrentUser();
+        FirebaseUser u = mAuth.getCurrentUser();
+        if (u == null) {
+            showResolvedPostOptions(p, v, false);
+            return;
+        }
+
+        firebaseManager.isForumPostSaved(p.getId(), task -> {
+            boolean isSaved = task.isSuccessful() && task.getResult() != null && task.getResult();
+            if (!isAdded()) return;
+            showResolvedPostOptions(p, v, isSaved);
+        });
+    }
+
+    private void showResolvedPostOptions(ForumPost p, View v, boolean isSaved) {
+        PopupMenu popup = new PopupMenu(getContext(), v);
+        FirebaseUser u = mAuth.getCurrentUser();
         if (u != null && p.getUserId().equals(u.getUid())) popup.getMenu().add("Delete");
+        popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
         popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(p);
+            else if (item.getTitle().equals("Save Post")) savePostForLater(p);
+            else if (item.getTitle().equals("Unsave Post")) unsavePost(p);
             else if (item.getTitle().equals("Report")) showReportDialog(p);
             return true;
         });
         popup.show();
+    }
+
+    private void savePostForLater(ForumPost p) {
+        firebaseManager.saveForumPost(p.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (isAdded()) Toast.makeText(requireContext(), "Post saved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (isAdded()) Toast.makeText(requireContext(), errorMessage != null ? errorMessage : "Failed to save post.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void unsavePost(ForumPost p) {
+        firebaseManager.unsaveForumPost(p.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (isAdded()) Toast.makeText(requireContext(), "Post unsaved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (isAdded()) Toast.makeText(requireContext(), errorMessage != null ? errorMessage : "Failed to unsave post.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     @Override public void onUserClick(String uid) {

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -521,15 +521,64 @@ public class NearbyHeatmapActivity extends AppCompatActivity
      * Takes prepared data and presents it on screen or in a dialog/menu.
      */
     private void showPostOptions(ForumPost p, View v, BottomSheetDialog dialog) {
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user == null) {
+            showResolvedPostOptions(p, v, dialog, false);
+            return;
+        }
+
+        firebaseManager.isForumPostSaved(p.getId(), task -> {
+            boolean isSaved = task.isSuccessful() && task.getResult() != null && task.getResult();
+            if (isFinishing() || isDestroyed()) return;
+            showResolvedPostOptions(p, v, dialog, isSaved);
+        });
+    }
+
+    private void showResolvedPostOptions(ForumPost p, View v, BottomSheetDialog dialog, boolean isSaved) {
         PopupMenu popup = new PopupMenu(this, v); FirebaseUser user = mAuth.getCurrentUser();
         if (user != null && p.getUserId().equals(user.getUid())) popup.getMenu().add("Delete");
+        popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
         popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(p, dialog);
+            else if (item.getTitle().equals("Save Post")) savePostForLater(p);
+            else if (item.getTitle().equals("Unsave Post")) unsavePost(p);
             else if (item.getTitle().equals("Report")) showReportDialog("post", p.getId());
             return true;
         });
         popup.show();
+    }
+
+    private void savePostForLater(ForumPost p) {
+        firebaseManager.saveForumPost(p.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override
+            public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(NearbyHeatmapActivity.this, "Post saved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(NearbyHeatmapActivity.this, errorMessage != null ? errorMessage : "Failed to save post.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void unsavePost(ForumPost p) {
+        firebaseManager.unsaveForumPost(p.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override
+            public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(NearbyHeatmapActivity.this, "Post unsaved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(NearbyHeatmapActivity.this, errorMessage != null ? errorMessage : "Failed to unsave post.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/birddex/app/PostDetailActivity.java
+++ b/app/src/main/java/com/birddex/app/PostDetailActivity.java
@@ -280,20 +280,69 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
      * Takes prepared data and presents it on screen or in a dialog/menu.
      */
     private void showPostOptions(ForumPost post, View view) {
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user == null) {
+            showResolvedPostOptions(post, view, false);
+            return;
+        }
+
+        firebaseManager.isForumPostSaved(post.getId(), task -> {
+            boolean isSaved = task.isSuccessful() && task.getResult() != null && task.getResult();
+            if (isFinishing() || isDestroyed()) return;
+            showResolvedPostOptions(post, view, isSaved);
+        });
+    }
+
+    private void showResolvedPostOptions(ForumPost post, View view, boolean isSaved) {
         PopupMenu popup = new PopupMenu(this, view);
         FirebaseUser user = mAuth.getCurrentUser();
         if (user != null && post.getUserId().equals(user.getUid())) {
             if (post.getTimestamp() != null && (System.currentTimeMillis() - post.getTimestamp().toDate().getTime() <= EDIT_WINDOW_MS)) popup.getMenu().add("Edit");
             popup.getMenu().add("Delete");
         }
+        popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
         popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Edit")) showEditPostDialog(post);
             else if (item.getTitle().equals("Delete")) showDeleteConfirmation(post);
+            else if (item.getTitle().equals("Save Post")) savePostForLater(post);
+            else if (item.getTitle().equals("Unsave Post")) unsavePost(post);
             else if (item.getTitle().equals("Report")) showReportDialog(post);
             return true;
         });
         popup.show();
+    }
+
+    private void savePostForLater(ForumPost post) {
+        firebaseManager.saveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override
+            public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(PostDetailActivity.this, "Post saved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(PostDetailActivity.this, errorMessage != null ? errorMessage : "Failed to save post.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void unsavePost(ForumPost post) {
+        firebaseManager.unsaveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override
+            public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(PostDetailActivity.this, "Post unsaved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(PostDetailActivity.this, errorMessage != null ? errorMessage : "Failed to unsave post.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/birddex/app/ProfileFragment.java
+++ b/app/src/main/java/com/birddex/app/ProfileFragment.java
@@ -83,9 +83,13 @@ public class ProfileFragment extends Fragment implements
     private ForumPostAdapter postsAdapter;
 
     private List<ForumPost> postList = new ArrayList<>();
+    private final List<ForumPost> savedPostList = new ArrayList<>();
     private DocumentSnapshot lastVisible;
+    private DocumentSnapshot lastSavedVisible;
     private boolean isFetching = false;
+    private boolean isFetchingSaved = false;
     private boolean isLastPage = false;
+    private boolean isSavedLastPage = false;
 
     private String profileUserId;
     private String currentUsername, currentBio, currentProfilePictureUrl;
@@ -100,6 +104,7 @@ public class ProfileFragment extends Fragment implements
 
     private boolean isNavigating = false;
     private int fetchGeneration = 0;
+    private int savedFetchGeneration = 0;
     private int favoriteFetchGeneration = 0;
 
     public ProfileFragment() {}
@@ -188,6 +193,7 @@ public class ProfileFragment extends Fragment implements
         isNavigating = false;
         if (profileListener == null) fetchUserProfile();
         refreshPosts();
+        if (isCurrentUser) refreshSavedPosts();
     }
 
     /**
@@ -206,9 +212,14 @@ public class ProfileFragment extends Fragment implements
         rvProfilePosts.setAdapter(postsAdapter);
         rvProfilePosts.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override public void onScrolled(@NonNull RecyclerView rv, int dx, int dy) {
-                if (dy > 0 && !isFetching && !isLastPage) {
-                    LinearLayoutManager lm = (LinearLayoutManager) rvProfilePosts.getLayoutManager();
-                    if (lm != null && lm.getChildCount() + lm.findFirstVisibleItemPosition() >= lm.getItemCount()) fetchPosts();
+                if (dy <= 0) return;
+                LinearLayoutManager lm = (LinearLayoutManager) rvProfilePosts.getLayoutManager();
+                if (lm == null || lm.getChildCount() + lm.findFirstVisibleItemPosition() < lm.getItemCount()) return;
+
+                if (isSavedTabSelected()) {
+                    if (!isFetchingSaved && !isSavedLastPage) fetchSavedPosts();
+                } else if (!isFetching && !isLastPage) {
+                    fetchPosts();
                 }
             }
         });
@@ -218,6 +229,14 @@ public class ProfileFragment extends Fragment implements
      * Updates object/screen state by storing a new value or reconfiguring a dependency.
      */
     private void setupTabs() {
+        if (isCurrentUser && profileTabLayout.getTabCount() == 2) {
+            profileTabLayout.addTab(profileTabLayout.newTab().setText("Saved"));
+        } else if (isCurrentUser && profileTabLayout.getTabCount() == 0) {
+            profileTabLayout.addTab(profileTabLayout.newTab().setText("Favorites"));
+            profileTabLayout.addTab(profileTabLayout.newTab().setText("Posts"));
+            profileTabLayout.addTab(profileTabLayout.newTab().setText("Saved"));
+        }
+
         profileTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
             @Override public void onTabSelected(TabLayout.Tab tab) { applyTabState(tab.getPosition()); }
             @Override public void onTabUnselected(TabLayout.Tab tab) {}
@@ -231,14 +250,30 @@ public class ProfileFragment extends Fragment implements
      */
     private void applyTabState(int position) {
         if (!isAdded()) return;
+
         if (position == 0) {
-            rvFavoriteCards.setVisibility(View.VISIBLE); rvProfilePosts.setVisibility(View.GONE); tvProfileTabEmpty.setVisibility(View.GONE);
-        } else {
-            rvFavoriteCards.setVisibility(View.GONE);
-            rvProfilePosts.setVisibility(postList.isEmpty() ? View.GONE : View.VISIBLE);
-            tvProfileTabEmpty.setVisibility(postList.isEmpty() ? View.VISIBLE : View.GONE);
-            if (postList.isEmpty()) tvProfileTabEmpty.setText("No posts yet.");
+            rvFavoriteCards.setVisibility(View.VISIBLE);
+            rvProfilePosts.setVisibility(View.GONE);
+            tvProfileTabEmpty.setVisibility(View.GONE);
+            return;
         }
+
+        rvFavoriteCards.setVisibility(View.GONE);
+
+        if (isCurrentUser && position == getSavedTabPosition()) {
+            if (savedPostList.isEmpty() && !isFetchingSaved && !isSavedLastPage) fetchSavedPosts();
+            postsAdapter.setPosts(new ArrayList<>(savedPostList));
+            rvProfilePosts.setVisibility(savedPostList.isEmpty() ? View.GONE : View.VISIBLE);
+            tvProfileTabEmpty.setVisibility(savedPostList.isEmpty() ? View.VISIBLE : View.GONE);
+            if (savedPostList.isEmpty()) tvProfileTabEmpty.setText("No saved posts yet.");
+            return;
+        }
+
+        if (postList.isEmpty() && !isFetching && !isLastPage) fetchPosts();
+        postsAdapter.setPosts(new ArrayList<>(postList));
+        rvProfilePosts.setVisibility(postList.isEmpty() ? View.GONE : View.VISIBLE);
+        tvProfileTabEmpty.setVisibility(postList.isEmpty() ? View.VISIBLE : View.GONE);
+        if (postList.isEmpty()) tvProfileTabEmpty.setText("No posts yet.");
     }
 
     /**
@@ -418,7 +453,6 @@ public class ProfileFragment extends Fragment implements
         if (profileUserId == null || isFetching || isLastPage || !isAdded()) return;
         isFetching = true;
         final int myGen = fetchGeneration;
-        // Set up or query the Firebase layer that supplies/stores this feature's data.
         Query query = db.collection("forumThreads").whereEqualTo("userId", profileUserId).orderBy("timestamp", Query.Direction.DESCENDING).limit(PAGE_SIZE);
         if (lastVisible != null) query = query.startAfter(lastVisible);
 
@@ -430,12 +464,75 @@ public class ProfileFragment extends Fragment implements
                     ForumPost post = doc.toObject(ForumPost.class);
                     if (post != null) { post.setId(doc.getId()); postList.add(post); }
                 }
-                postsAdapter.setPosts(new ArrayList<>(postList));
                 if (value.size() < PAGE_SIZE) isLastPage = true;
             } else isLastPage = true;
             isFetching = false;
+            if (!isSavedTabSelected()) postsAdapter.setPosts(new ArrayList<>(postList));
             applyTabState(profileTabLayout.getSelectedTabPosition());
         }).addOnFailureListener(e -> { if (myGen == fetchGeneration) isFetching = false; });
+    }
+
+    private void fetchSavedPosts() {
+        if (!isCurrentUser || profileUserId == null || isFetchingSaved || isSavedLastPage || !isAdded()) return;
+        isFetchingSaved = true;
+        final int myGen = savedFetchGeneration;
+
+        Query query = db.collection("users")
+                .document(profileUserId)
+                .collection("savedPosts")
+                .orderBy("savedAt", Query.Direction.DESCENDING)
+                .limit(PAGE_SIZE);
+
+        if (lastSavedVisible != null) query = query.startAfter(lastSavedVisible);
+
+        query.get().addOnSuccessListener(value -> {
+            if (!isAdded() || myGen != savedFetchGeneration) return;
+
+            if (value != null && !value.isEmpty()) {
+                lastSavedVisible = value.getDocuments().get(value.size() - 1);
+                List<DocumentSnapshot> savedDocs = value.getDocuments();
+                List<com.google.android.gms.tasks.Task<DocumentSnapshot>> postTasks = new ArrayList<>();
+
+                for (DocumentSnapshot savedDoc : savedDocs) {
+                    String threadId = savedDoc.getString("threadId");
+                    if (threadId != null && !threadId.isEmpty()) {
+                        postTasks.add(db.collection("forumThreads").document(threadId).get());
+                    }
+                }
+
+                if (postTasks.isEmpty()) {
+                    if (value.size() < PAGE_SIZE) isSavedLastPage = true;
+                    isFetchingSaved = false;
+                    applyTabState(profileTabLayout.getSelectedTabPosition());
+                    return;
+                }
+
+                com.google.android.gms.tasks.Tasks.whenAllComplete(postTasks).addOnSuccessListener(done -> {
+                    if (!isAdded() || myGen != savedFetchGeneration) return;
+
+                    for (com.google.android.gms.tasks.Task<DocumentSnapshot> task : postTasks) {
+                        if (!task.isSuccessful() || task.getResult() == null || !task.getResult().exists()) continue;
+                        DocumentSnapshot doc = task.getResult();
+                        ForumPost post = doc.toObject(ForumPost.class);
+                        if (post != null) {
+                            post.setId(doc.getId());
+                            savedPostList.add(post);
+                        }
+                    }
+
+                    if (value.size() < PAGE_SIZE) isSavedLastPage = true;
+                    isFetchingSaved = false;
+                    if (isSavedTabSelected()) postsAdapter.setPosts(new ArrayList<>(savedPostList));
+                    applyTabState(profileTabLayout.getSelectedTabPosition());
+                }).addOnFailureListener(e -> {
+                    if (myGen == savedFetchGeneration) isFetchingSaved = false;
+                });
+            } else {
+                isSavedLastPage = true;
+                isFetchingSaved = false;
+                applyTabState(profileTabLayout.getSelectedTabPosition());
+            }
+        }).addOnFailureListener(e -> { if (myGen == savedFetchGeneration) isFetchingSaved = false; });
     }
 
     /**
@@ -445,15 +542,37 @@ public class ProfileFragment extends Fragment implements
         fetchGeneration++;
         isFetching = false; lastVisible = null; isLastPage = false;
         postList.clear();
-        if (postsAdapter != null) postsAdapter.setPosts(new ArrayList<>());
+        if (postsAdapter != null && !isSavedTabSelected()) postsAdapter.setPosts(new ArrayList<>());
         fetchPosts();
+    }
+
+    private void refreshSavedPosts() {
+        if (!isCurrentUser) return;
+        savedFetchGeneration++;
+        isFetchingSaved = false; lastSavedVisible = null; isSavedLastPage = false;
+        savedPostList.clear();
+        if (postsAdapter != null && isSavedTabSelected()) postsAdapter.setPosts(new ArrayList<>());
+        fetchSavedPosts();
+    }
+
+    private boolean isSavedTabSelected() {
+        return isCurrentUser && profileTabLayout != null && profileTabLayout.getSelectedTabPosition() == getSavedTabPosition();
+    }
+
+    private int getSavedTabPosition() {
+        return isCurrentUser ? 2 : -1;
     }
 
     /**
      * Updates object/screen state by storing a new value or reconfiguring a dependency.
      */
     private void setupSwipeRefresh() {
-        swipeRefreshLayout.setOnRefreshListener(() -> { fetchUserProfile(); refreshPosts(); swipeRefreshLayout.setRefreshing(false); });
+        swipeRefreshLayout.setOnRefreshListener(() -> {
+            fetchUserProfile();
+            refreshPosts();
+            if (isCurrentUser) refreshSavedPosts();
+            swipeRefreshLayout.setRefreshing(false);
+        });
     }
 
     @Override public void onLikeClick(ForumPost post) {
@@ -483,15 +602,61 @@ public class ProfileFragment extends Fragment implements
     }
 
     @Override public void onOptionsClick(ForumPost post, View view) {
+        if (mAuth.getCurrentUser() == null) {
+            showResolvedPostOptions(post, view, false);
+            return;
+        }
+
+        firebaseManager.isForumPostSaved(post.getId(), task -> {
+            boolean isSaved = task.isSuccessful() && task.getResult() != null && task.getResult();
+            if (!isAdded()) return;
+            showResolvedPostOptions(post, view, isSaved);
+        });
+    }
+
+    private void showResolvedPostOptions(ForumPost post, View view, boolean isSaved) {
         PopupMenu popup = new PopupMenu(requireContext(), view);
         if (mAuth.getUid() != null && mAuth.getUid().equals(post.getUserId())) popup.getMenu().add("Delete");
+        popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
         popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(post);
+            else if (item.getTitle().equals("Save Post")) savePostForLater(post);
+            else if (item.getTitle().equals("Unsave Post")) unsavePost(post);
             else showReportDialog(post);
             return true;
         });
         popup.show();
+    }
+
+    private void savePostForLater(ForumPost post) {
+        firebaseManager.saveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (!isAdded()) return;
+                Toast.makeText(requireContext(), "Post saved", Toast.LENGTH_SHORT).show();
+                refreshSavedPosts();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (!isAdded()) return;
+                Toast.makeText(requireContext(), errorMessage != null ? errorMessage : "Failed to save post.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void unsavePost(ForumPost post) {
+        firebaseManager.unsaveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (!isAdded()) return;
+                Toast.makeText(requireContext(), "Post unsaved", Toast.LENGTH_SHORT).show();
+                refreshSavedPosts();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (!isAdded()) return;
+                Toast.makeText(requireContext(), errorMessage != null ? errorMessage : "Failed to unsave post.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     @Override public void onUserClick(String userId) {
@@ -582,7 +747,15 @@ public class ProfileFragment extends Fragment implements
         });
     }
 
-    private void showDeleteConfirmation(ForumPost post) { new AlertDialog.Builder(requireContext()).setTitle("Delete Post").setPositiveButton("Delete", (d, w) -> firebaseManager.deleteForumPost(post.getId(), t -> refreshPosts())).show(); }
+    private void showDeleteConfirmation(ForumPost post) {
+        new AlertDialog.Builder(requireContext())
+                .setTitle("Delete Post")
+                .setPositiveButton("Delete", (d, w) -> firebaseManager.deleteForumPost(post.getId(), t -> {
+                    refreshPosts();
+                    if (isCurrentUser) refreshSavedPosts();
+                }))
+                .show();
+    }
 
     /**
      * Takes prepared data and presents it on screen or in a dialog/menu.

--- a/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
+++ b/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
@@ -516,11 +516,11 @@ public class UserSocialProfileActivity extends AppCompatActivity implements
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         if (user == null || post.getId() == null || postLikeInFlight.contains(post.getId())) return;
         postLikeInFlight.add(post.getId());
-        
+
         String userId = user.getUid();
         if (post.getLikedBy() == null) post.setLikedBy(new HashMap<>());
         boolean currentlyLiked = post.getLikedBy().containsKey(userId);
-        
+
         // Optimistic UI update
         int currentCount = post.getLikeCount();
         if (currentlyLiked) {
@@ -579,44 +579,84 @@ public class UserSocialProfileActivity extends AppCompatActivity implements
     }
 
     @Override public void onOptionsClick(ForumPost post, View view) {
+        FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+        if (currentUser == null) {
+            showResolvedPostOptions(post, view, false);
+            return;
+        }
+
+        firebaseManager.isForumPostSaved(post.getId(), task -> {
+            boolean isSaved = task.isSuccessful() && task.getResult() != null && task.getResult();
+            if (isFinishing() || isDestroyed()) return;
+            showResolvedPostOptions(post, view, isSaved);
+        });
+    }
+
+    private void showResolvedPostOptions(ForumPost post, View view, boolean isSaved) {
         PopupMenu popup = new PopupMenu(this, view);
         FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
         if (currentUser != null && post.getUserId().equals(currentUser.getUid())) {
             popup.getMenu().add("Delete");
         }
+        popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
         popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) {
                 new AlertDialog.Builder(this)
                         .setTitle("Delete Post")
                         .setMessage("Are you sure you want to delete this post?")
-                        /**
-                         * Updates object/screen state by storing a new value or reconfiguring a dependency.
-                         * User-facing feedback is shown here so the user knows whether the action succeeded, failed,
-                         * or needs attention.
-                         */
                         .setPositiveButton("Delete", (d, w) -> {
                             firebaseManager.deleteForumPost(post.getId(), task -> {
                                 if (task.isSuccessful()) {
                                     postList.remove(post);
                                     adapter.setPosts(new ArrayList<>(postList));
                                     tvPostCount.setText(String.valueOf(postList.size()));
-                                    // Give the user immediate feedback about the result of this action.
                                     Toast.makeText(this, "Post deleted", Toast.LENGTH_SHORT).show();
+                                } else if (task.getException() != null) {
+                                    Toast.makeText(this, task.getException().getMessage(), Toast.LENGTH_SHORT).show();
                                 }
                             });
                         })
                         .setNegativeButton("Cancel", null)
                         .show();
-            /**
-             * Main logic block for this part of the feature.
-             */
+            } else if (item.getTitle().equals("Save Post")) {
+                savePostForLater(post);
+            } else if (item.getTitle().equals("Unsave Post")) {
+                unsavePost(post);
             } else if (item.getTitle().equals("Report")) {
                 showReportDialog(post);
             }
             return true;
         });
         popup.show();
+    }
+
+    private void savePostForLater(ForumPost post) {
+        firebaseManager.saveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(UserSocialProfileActivity.this, "Post saved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(UserSocialProfileActivity.this, errorMessage != null ? errorMessage : "Failed to save post.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void unsavePost(ForumPost post) {
+        firebaseManager.unsaveForumPost(post.getId(), new FirebaseManager.ForumWriteListener() {
+            @Override public void onSuccess() {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(UserSocialProfileActivity.this, "Post unsaved", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override public void onFailure(String errorMessage) {
+                if (isFinishing() || isDestroyed()) return;
+                Toast.makeText(UserSocialProfileActivity.this, errorMessage != null ? errorMessage : "Failed to unsave post.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     /**

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,17 +20,21 @@ service cloud.firestore {
     }
 
     function onlySessionFieldUpdate() {
-  		return request.resource.data.diff(resource.data).affectedKeys()
-    	.hasOnly(['currentSessionId']) &&
-    	request.resource.data.currentSessionId is string &&
-    	request.resource.data.currentSessionId.size() > 0;
-		}
+      return request.resource.data.diff(resource.data).affectedKeys()
+        .hasOnly(['currentSessionId']) &&
+        request.resource.data.currentSessionId is string &&
+        request.resource.data.currentSessionId.size() > 0;
+    }
 
     // Fields that only Cloud Functions should ever write.
-    // If any of these are in the incoming diff, block the client write.
+    // Username, bio, and profilePictureUrl are now backend-moderated too.
     function onlyClientProfileFields() {
       return !request.resource.data.diff(resource.data).affectedKeys()
         .hasAny([
+          'username',
+          'bio',
+          'profilePictureUrl',
+
           'totalPoints', 'totalBirds', 'duplicateBirds',
           'openAiRequestsRemaining', 'openAiCooldownResetTimestamp',
           'pfpChangesToday', 'pfpCooldownResetTimestamp',
@@ -40,16 +44,31 @@ service cloud.firestore {
         ]);
     }
 
+    // Client-side forum thread engagement still allowed for now.
+    // If likes/views are later moved to Cloud Functions too, set forum thread updates to false.
+    function onlyClientForumThreadEngagementUpdate() {
+      return request.resource.data.diff(resource.data).affectedKeys()
+        .hasOnly(['likeCount', 'likedBy', 'viewCount', 'viewedBy']);
+    }
+
+    // Client-side comment likes still allowed for now.
+    // If comment likes are later moved to Cloud Functions too, set comment updates to false.
+    function onlyClientCommentLikeUpdate() {
+      return request.resource.data.diff(resource.data).affectedKeys()
+        .hasOnly(['likedBy']);
+    }
+
     // --- Users Collection ---
     match /users/{userId} {
       // Any signed-in user can read public profiles
       allow read: if isSignedIn();
 
-      // Owner can update their own profile, but cannot touch CF-managed fields
+      // Owner can update only non-CF-managed profile fields,
+      // or update currentSessionId only.
       allow update: if isOwner(userId) && (
-  			onlyClientProfileFields() ||
-  			onlySessionFieldUpdate()
-				);
+        onlyClientProfileFields() ||
+        onlySessionFieldUpdate()
+      );
 
       // Creation/deletion handled by Cloud Functions only
       allow create, delete: if false;
@@ -84,9 +103,15 @@ service cloud.firestore {
       }
 
       // --- Settings (CF-managed: cooldowns, post limits, PFP limits) ---
-      // Clients can read their own settings (e.g. to display PFP changes remaining)
-      // but cannot write — all writes go through Cloud Functions.
       match /settings/{docId} {
+        allow read: if isOwner(userId);
+        allow write: if false; // Cloud Functions only
+      }
+
+      // --- Saved Posts ---
+      // Save/unsave goes through Cloud Functions.
+      // Client can read their own saved posts feed.
+      match /savedPosts/{threadId} {
         allow read: if isOwner(userId);
         allow write: if false; // Cloud Functions only
       }
@@ -98,59 +123,32 @@ service cloud.firestore {
       allow write: if false; // Cloud Functions (initializeUser) only
     }
 
-  	match /forumThreads/{postId} {
-  		allow read: if isSignedIn();
+    // --- Forum Threads ---
+    match /forumThreads/{postId} {
+      allow read: if isSignedIn();
 
-  	// Only create if the userId field matches the requester
-  		allow create: if isSignedIn() && incomingDataOwned();
+      // Post create/edit/delete now go through Cloud Functions only.
+      allow create: if false;
+      allow delete: if false;
 
-  		allow update: if isSignedIn() && (
-    // Owner can edit for 5 minutes, but NOT location/map fields
-    (
-      isOwnerOfResource() &&
-      resource.data.createdAt != null &&
-      request.time < resource.data.createdAt + duration.value(5, "m") &&
-      !request.resource.data.diff(resource.data).affectedKeys().hasAny([
-        'showLocation',
-        'latitude',
-        'longitude',
-        'locationId',
-        'localityName',
-        'state',
-        'country',
-        'userId',
-        'createdAt'
-      ])
-    ) ||
-    // Other signed-in users can only update engagement fields
-    request.resource.data.diff(resource.data).affectedKeys()
-      .hasOnly(['likeCount', 'likedBy', 'viewCount', 'viewedBy', 'commentCount'])
-  	);
+      // Keep only engagement fields client-writable for now.
+      allow update: if isSignedIn() && onlyClientForumThreadEngagementUpdate();
 
-  			allow delete: if isSignedIn() && isOwnerOfResource();
+      match /comments/{commentId} {
+        allow read: if isSignedIn();
 
-  		match /comments/{commentId} {
-    	allow read: if isSignedIn();
+        // Comment/reply create/delete now go through Cloud Functions only.
+        allow create: if false;
+        allow delete: if false;
 
-    		allow create: if isSignedIn() && incomingDataOwned();
-
-    		allow delete: if isSignedIn() && (
-      	isOwnerOfResource() ||
-      	get(/databases/$(database)/documents/forumThreads/$(postId)).data.userId == request.auth.uid
-    		);
-
-    		allow update: if isSignedIn() && (
-      	isOwnerOfResource() ||
-      	request.resource.data.diff(resource.data).affectedKeys()
-        .hasOnly(['likedBy'])
-    		);
-  		}
-		}
+        // Keep only comment-like field client-writable for now.
+        allow update: if isSignedIn() && onlyClientCommentLikeUpdate();
+      }
+    }
 
     // --- Backlog Collection for Deletions ---
     match /deletedforum_backlog/{docId} {
-      allow create: if isSignedIn();
-      allow read, update, delete: if false;
+      allow read, write: if false; // Cloud Functions only
     }
 
     // --- Reports Collection ---
@@ -164,26 +162,27 @@ service cloud.firestore {
       allow read: if isSignedIn();
       allow write: if false;
     }
+
     match /birdFacts/{birdId} {
       allow read: if isSignedIn();
       allow write: if false;
+
       match /hunterFacts/{factId} {
         allow read: if isSignedIn();
         allow write: if false;
       }
     }
 
-    // --- User Bird Sightings (written by recordBirdSighting CF only) ---
+    // --- User Bird Sightings ---
     match /userBirds/{sightingId} {
       allow read: if isSignedIn() && isOwnerOfResource();
       allow create: if isSignedIn() && incomingDataOwned();
       allow update, delete: if isSignedIn() && isOwnerOfResource();
     }
+
     match /userBirdSightings/{sightingId} {
-      // Anyone signed in can read (powers the heatmap for all users)
       allow read: if isSignedIn();
-      // Writes are CF-only — recordBirdSighting CF uses admin SDK
-      allow write: if false;
+      allow write: if false; // Cloud Functions only
     }
 
     // --- Identifications (Internal logging only) ---
@@ -197,8 +196,6 @@ service cloud.firestore {
       allow create: if isSignedIn();
 
       // Allow updates ONLY if the coordinates haven't changed.
-      // This lets the app refresh the locality name but stops clients from
-      // changing the actual physical location of a known ID.
       allow update: if isSignedIn() &&
         request.resource.data.latitude == resource.data.latitude &&
         request.resource.data.longitude == resource.data.longitude;
@@ -223,9 +220,11 @@ service cloud.firestore {
     match /processedEvents/{eventId} {
       allow read, write: if false; // Cloud Functions only
     }
+
     match /processedAIEvents/{eventId} {
       allow read, write: if false; // Cloud Functions only
     }
+
     match /schedulerLocks/{lockId} {
       allow read, write: if false; // Cloud Functions only
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -3549,3 +3549,109 @@ exports.deleteForumComment = onCall(async (request) => {
         throw new HttpsError("internal", `Failed to delete comment: ${error.message}`);
     }
 });
+
+
+/**
+ * Saves a forum post for the current user so it can be viewed later from the profile screen.
+ * The saved post document ID matches the thread ID so duplicate entries cannot be created.
+ */
+exports.saveForumPost = onCall(async (request) => {
+    if (!request.auth) throw new HttpsError("unauthenticated", "Login required.");
+
+    const userId = request.auth.uid;
+    const data = request.data || {};
+    const threadId = sanitizeText(data.threadId || "", 200).trim();
+
+    if (!threadId) {
+        throw new HttpsError("invalid-argument", "threadId is required.");
+    }
+
+    const threadRef = db.collection("forumThreads").doc(threadId);
+    const savedRef = db.collection("users").doc(userId).collection("savedPosts").doc(threadId);
+
+    try {
+        await db.runTransaction(async (transaction) => {
+            const [threadSnap, savedSnap] = await Promise.all([
+                transaction.get(threadRef),
+                transaction.get(savedRef),
+            ]);
+
+            if (!threadSnap.exists) {
+                throw new HttpsError("not-found", "Post not found.");
+            }
+
+            if (!savedSnap.exists) {
+                transaction.set(savedRef, {
+                    threadId,
+                    savedAt: admin.firestore.FieldValue.serverTimestamp(),
+                    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+                });
+            }
+        });
+
+        logger.info(`saveForumPost: saved thread ${threadId} for user ${userId}`);
+        return { success: true, threadId };
+    } catch (error) {
+        logger.error("saveForumPost failed:", error);
+        if (error instanceof HttpsError) throw error;
+        throw new HttpsError("internal", `Failed to save post: ${error.message}`);
+    }
+});
+
+/**
+ * Returns whether the current user has saved a given forum post.
+ * This lets the app resolve Save/Unsave labels without depending on client Firestore read rules.
+ */
+exports.getForumPostSaveState = onCall(async (request) => {
+    if (!request.auth) throw new HttpsError("unauthenticated", "Login required.");
+
+    const userId = request.auth.uid;
+    const data = request.data || {};
+    const threadId = sanitizeText(data.threadId || "", 200).trim();
+
+    if (!threadId) {
+        throw new HttpsError("invalid-argument", "threadId is required.");
+    }
+
+    const savedRef = db.collection("users").doc(userId).collection("savedPosts").doc(threadId);
+
+    try {
+        const savedSnap = await savedRef.get();
+        return {
+            success: true,
+            threadId,
+            saved: savedSnap.exists,
+        };
+    } catch (error) {
+        logger.error("getForumPostSaveState failed:", error);
+        if (error instanceof HttpsError) throw error;
+        throw new HttpsError("internal", `Failed to read saved post state: ${error.message}`);
+    }
+});
+
+/**
+ * Removes a saved forum post entry for the current user.
+ */
+exports.unsaveForumPost = onCall(async (request) => {
+    if (!request.auth) throw new HttpsError("unauthenticated", "Login required.");
+
+    const userId = request.auth.uid;
+    const data = request.data || {};
+    const threadId = sanitizeText(data.threadId || "", 200).trim();
+
+    if (!threadId) {
+        throw new HttpsError("invalid-argument", "threadId is required.");
+    }
+
+    const savedRef = db.collection("users").doc(userId).collection("savedPosts").doc(threadId);
+
+    try {
+        await savedRef.delete();
+        logger.info(`unsaveForumPost: removed saved thread ${threadId} for user ${userId}`);
+        return { success: true, threadId };
+    } catch (error) {
+        logger.error("unsaveForumPost failed:", error);
+        if (error instanceof HttpsError) throw error;
+        throw new HttpsError("internal", `Failed to unsave post: ${error.message}`);
+    }
+});


### PR DESCRIPTION
…ecurity rules.

- **Forum Post Saving**:
    - Added Cloud Functions `saveForumPost`, `getForumPostSaveState`, and `unsaveForumPost` to manage saved posts server-side.
    - Integrated "Save Post" and "Unsave Post" options into post overflow menus across `ForumFragment`, `NearbyHeatmapActivity`, `UserSocialProfileActivity`, and `PostDetailActivity`.
    - Added a "Saved" tab to the user profile to display and paginate saved forum threads.
    - Updated `FirebaseManager` with methods to invoke the new save/unsave backend functions.

- **Security & Firestore Rules**:
    - Restricted `username`, `bio`, and `profilePictureUrl` updates to backend-moderated processes only.
    - Moved forum thread and comment creation/deletion to Cloud Functions by disabling client-side `create` and `delete` permissions.
    - Added `savedPosts` subcollection rules allowing only owner reads and Cloud Function writes.
    - Refined `onlyClientProfileFields` and other helper functions to ensure strict field-level validation.

- **UI & Bug Fixes**:
    - Improved tab state management in `ProfileFragment` to handle "Favorites", "Posts", and "Saved" views.
    - Fixed a bug in `UserSocialProfileActivity` where deletion failure was not properly toasted to the user.
    - Standardized menu option handling with `showResolvedPostOptions` to dynamically update labels based on current save state.