### PR TITLE
Implemented a time-based expiration system for forum post location pi…

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumPost.java
+++ b/app/src/main/java/com/birddex/app/ForumPost.java
@@ -41,6 +41,7 @@ public class ForumPost {
     private boolean notificationSent;
     private boolean likeNotificationSent;
     private Timestamp lastViewedAt;
+    private Timestamp heatmapExpiresAt;
 
     /**
      * Constructor that stores incoming dependencies/values so this object starts in a usable
@@ -81,7 +82,7 @@ public class ForumPost {
     @Exclude // Prevents Firestore from writing an 'id' field while allowing code to use getId()
     public String getId() { return postId; }
     public void setId(String id) { this.postId = id; }
-    
+
     public String getPostId() { return postId; }
     public void setPostId(String postId) { this.postId = postId; }
 
@@ -129,4 +130,6 @@ public class ForumPost {
     public void setLikeNotificationSent(boolean likeNotificationSent) { this.likeNotificationSent = likeNotificationSent; }
     public Timestamp getLastViewedAt() { return lastViewedAt; }
     public void setLastViewedAt(Timestamp lastViewedAt) { this.lastViewedAt = lastViewedAt; }
+    public Timestamp getHeatmapExpiresAt() { return heatmapExpiresAt; }
+    public void setHeatmapExpiresAt(Timestamp heatmapExpiresAt) { this.heatmapExpiresAt = heatmapExpiresAt; }
 }

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -119,6 +119,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
 
     private static final double SEARCH_RADIUS_METERS = 50000d;
     private static final long SIGHTING_RECENCY_MS = 72L * 60 * 60 * 1000;
+    private static final long FORUM_HEATMAP_POST_TTL_MS = 48L * 60 * 60 * 1000;
 
     private static final double HOTSPOT_BUCKET_SIZE = 0.02d;
     private static final double HOTSPOT_CIRCLE_RADIUS_METERS = 900d;
@@ -395,10 +396,38 @@ public class NearbyHeatmapActivity extends AppCompatActivity
             ForumPost p = doc.toObject(ForumPost.class);
             if (p != null && p.getLatitude() != null) {
                 p.setId(doc.getId());
+                if (isForumPostExpiredFromHeatmap(p)) {
+                    continue;
+                }
                 boolean inBounds = currentVisibleBounds == null || currentVisibleBounds.contains(new LatLng(p.getLatitude(), p.getLongitude()));
                 if (inBounds && (showGraphic || !p.isHunted())) addPinToMap(p);
             }
         }
+    }
+
+    /**
+     * Decides whether a location-sharing forum post has aged out of the heat map.
+     *
+     * Newer posts use the backend-written `heatmapExpiresAt` field. Older existing posts that do
+     * not have that field fall back to `timestamp + 48h` so the cutoff still works without a full
+     * migration.
+     */
+    private boolean isForumPostExpiredFromHeatmap(ForumPost post) {
+        if (post == null) return true;
+
+        Date now = new Date();
+
+        if (post.getHeatmapExpiresAt() != null) {
+            Date expiresAt = post.getHeatmapExpiresAt().toDate();
+            return expiresAt != null && !expiresAt.after(now);
+        }
+
+        if (post.getTimestamp() != null) {
+            Date createdAt = post.getTimestamp().toDate();
+            return createdAt != null && (createdAt.getTime() + FORUM_HEATMAP_POST_TTL_MS) <= now.getTime();
+        }
+
+        return false;
     }
 
     /**

--- a/functions/index.js
+++ b/functions/index.js
@@ -44,6 +44,7 @@ const CONFIG = {
     COOLDOWN_PERIOD_MS: 24 * 60 * 60 * 1000,       // 24 hours
     FACT_CACHE_LIFETIME_MS: 30 * 24 * 60 * 60 * 1000, // 30 days
     EBIRD_CACHE_TTL_MS: 72 * 60 * 60 * 1000,          // 72 hours
+    FORUM_HEATMAP_TTL_MS: 48 * 60 * 60 * 1000,        // 48 hours
     FORUM_ARCHIVE_DAYS_MS: 7 * 24 * 60 * 60 * 1000,   // 7 days
     UNVERIFIED_USER_TTL_MS: 72 * 60 * 60 * 1000,      // 72 hours
     FIRESTORE_BATCH_SIZE: 400,  // Firestore max is 500; using 400 for safety
@@ -2411,29 +2412,42 @@ Respond STRICTLY in JSON format with two keys:
 });
 
 // ======================================================
-// archiveOldForumPosts (scheduled, every 24h)
+// archiveOldForumPosts (disabled)
 // ======================================================
 /**
- * Main backend logic block for this Firebase Functions file.
- * This code reads/writes Firestore documents, so it is part of the persistent backend state
- * for the app.
+ * Forum posts now stay visible indefinitely in the social feed.
+ * This scheduled function is intentionally a no-op so older posts are not removed from forumThreads.
  */
 exports.archiveOldForumPosts = onSchedule({
     schedule: "every 24 hours",
     timeZone: "America/New_York",
     timeoutSeconds: 540
 }, async (event) => {
-    // This is where the function touches Firestore documents/collections for the requested action.
-    const lockRef = db.collection("schedulerLocks").doc("archiveOldForumPosts");
-    const STALE_LOCK_MS = 10 * 60 * 1000; // 10 minutes — release if previous run crashed
+    logger.info("archiveOldForumPosts is disabled. Forum posts remain visible in forumThreads.");
+    return null;
+});
 
-    // Acquire lock
+// ======================================================
+// expireForumHeatmapPins (scheduled, every 1 hour)
+// ======================================================
+/**
+ * Clears forum post map visibility after 48 hours so older location pins stop cluttering the heat map
+ * while the post itself stays visible in the forum feed.
+ */
+exports.expireForumHeatmapPins = onSchedule({
+    schedule: "every 1 hours",
+    timeZone: "America/New_York",
+    timeoutSeconds: 540
+}, async (event) => {
+    const lockRef = db.collection("schedulerLocks").doc("expireForumHeatmapPins");
+    const STALE_LOCK_MS = 10 * 60 * 1000;
+
     const lockAcquired = await db.runTransaction(async (t) => {
         const lockDoc = await t.get(lockRef);
         if (lockDoc.exists) {
             const startedAt = lockDoc.data().startedAt?.toDate();
             if (startedAt && (Date.now() - startedAt.getTime()) < STALE_LOCK_MS) {
-                return false; // another instance is running
+                return false;
             }
         }
         t.set(lockRef, { startedAt: admin.firestore.FieldValue.serverTimestamp() });
@@ -2441,58 +2455,45 @@ exports.archiveOldForumPosts = onSchedule({
     });
 
     if (!lockAcquired) {
-        logger.info("archiveOldForumPosts: Another instance is already running. Skipping.");
+        logger.info("expireForumHeatmapPins: Another instance is already running. Skipping.");
         return null;
     }
 
-    logger.info("Starting scheduled forum post archiving...");
-    const archiveThreshold = new Date(Date.now() - CONFIG.FORUM_ARCHIVE_DAYS_MS);
-    const storageBucket = admin.storage().bucket();
+    logger.info("Starting forum heatmap pin expiration cycle...");
+    const now = admin.firestore.Timestamp.now();
 
     try {
-        const postsToArchive = await db.collection("forumThreads")
-            .where("timestamp", "<", archiveThreshold)
+        const expiredSnap = await db.collection("forumThreads")
+            .where("heatmapExpiresAt", "<=", now)
             .limit(500)
             .get();
 
-        if (postsToArchive.empty) {
-            logger.info("No old posts found to archive.");
+        if (expiredSnap.empty) {
+            logger.info("No expired forum heatmap pins found.");
             return null;
         }
 
-        logger.info(`Archiving ${postsToArchive.size} posts...`);
+        logger.info(`Expiring ${expiredSnap.size} forum heatmap pins...`);
 
-        await Promise.all(postsToArchive.docs.map(async (postDoc) => {
-            const postData = postDoc.data();
-            const postId = postDoc.id;
-            const commentsSnap = await postDoc.ref.collection("comments").get();
-            const comments = commentsSnap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-
-            // FIX #20: Storage write and batch.commit() are non-atomic — a crash between
-            // them causes the next retry to re-archive (overwriting the Storage file) before
-            // deleting.  Guard: skip the Storage write if the file already exists so retries
-            // are safe (the archive was already written; just proceed to delete Firestore docs).
-            const archiveFile = storageBucket.file(`archived_posts/${postId}.json`);
-            const [archiveExists] = await archiveFile.exists();
-            if (!archiveExists) {
-                await archiveFile.save(
-                    JSON.stringify({ ...postData, id: postId, archivedAt: new Date().toISOString(), comments }),
-                    { contentType: "application/json" }
-                );
+        const batch = db.batch();
+        expiredSnap.docs.forEach((doc) => {
+            const data = doc.data() || {};
+            if (data.showLocation === true) {
+                batch.update(doc.ref, {
+                    showLocation: false,
+                    latitude: null,
+                    longitude: null,
+                });
             }
+        });
+        await batch.commit();
 
-            const batch = db.batch();
-            commentsSnap.forEach(doc => batch.delete(doc.ref));
-            batch.delete(postDoc.ref);
-            await batch.commit();
-        }));
-
-        logger.info("Forum post archiving cycle complete.");
+        logger.info("Forum heatmap pin expiration cycle complete.");
     } catch (error) {
-        logger.error("Error during forum post archiving:", error);
+        logger.error("Error during forum heatmap pin expiration:", error);
     } finally {
         await lockRef.delete().catch(e =>
-            logger.warn("Failed to release archive lock:", e)
+            logger.warn("Failed to release forum heatmap expiration lock:", e)
         );
     }
     return null;
@@ -3820,6 +3821,9 @@ exports.createForumPost = onCall(async (request) => {
                 notificationSent: false,
                 likeNotificationSent: false,
                 lastViewedAt: null,
+                heatmapExpiresAt: showLocation
+                    ? admin.firestore.Timestamp.fromMillis(Date.now() + CONFIG.FORUM_HEATMAP_TTL_MS)
+                    : null,
             };
 
             t.create(postRef, postData);


### PR DESCRIPTION
…ns on the heatmap while disabling permanent post archiving to keep the social feed intact.

### **Backend & Cloud Functions**:
- **Forum Heatmap Expiration**:
    - Introduced `expireForumHeatmapPins`, a scheduled function that runs hourly to hide location pins from the map after 48 hours.
    - Added `FORUM_HEATMAP_TTL_MS` (48 hours) to the global configuration.
    - Updated post creation logic to calculate and store a `heatmapExpiresAt` timestamp.
    - The expiration process updates `showLocation` to `false` and clears coordinates without deleting the post.
- **Archive Policy Change**:
    - Disabled `archiveOldForumPosts` by converting it into a no-op, ensuring posts remain visible in the forum indefinitely.
- **Infrastructure**:
    - Implemented a locking mechanism (`expireForumHeatmapPins` lock) to prevent concurrent execution of the expiration task.

### **Mobile App Enhancements**:
- **Heatmap Logic**:
    - Updated `NearbyHeatmapActivity` to filter out expired forum pins.
    - Implemented `isForumPostExpiredFromHeatmap` with fallback logic: it uses the new `heatmapExpiresAt` field or calculates expiration based on the creation timestamp for legacy posts.
- **Data Models**:
    - Updated the `ForumPost` class to include the `heatmapExpiresAt` field with corresponding getters and setters.