### PR TITLE
Updated cache TTL durations for core bird lists, details, and wiki fa…

### DIFF
--- a/app/src/main/java/com/birddex/app/BirdCacheManager.java
+++ b/app/src/main/java/com/birddex/app/BirdCacheManager.java
@@ -39,8 +39,8 @@ public class BirdCacheManager {
     private static final String KEY_BIRD_DETAILS_TIMESTAMP_PREFIX = "bird_details_timestamp_";
 
     public static final long NEARBY_CACHE_TTL_MS = 10L * 60L * 1000L;
-    public static final long CORE_BIRD_LIST_CACHE_TTL_MS = 12L * 60L * 60L * 1000L;
-    public static final long BIRD_DETAILS_CACHE_TTL_MS = 12L * 60L * 60L * 1000L;
+    public static final long CORE_BIRD_LIST_CACHE_TTL_MS = 24L * 60L * 60L * 1000L;
+    public static final long BIRD_DETAILS_CACHE_TTL_MS = 3L * 24L * 60L * 60L * 1000L;
 
     private static List<Bird> inMemoryNearbyBirds = new ArrayList<>();
     private static long inMemoryNearbyTimestamp = 0L;

--- a/app/src/main/java/com/birddex/app/BirdWikiActivity.java
+++ b/app/src/main/java/com/birddex/app/BirdWikiActivity.java
@@ -51,7 +51,7 @@ public class BirdWikiActivity extends AppCompatActivity {
     // Local app cache for Cloud Function facts so the page does not repeatedly call
     // the function when Firestore cache is missing but recent facts were already fetched.
     private static final String FACTS_CACHE_PREFS = "birdwiki_facts_cache";
-    private static final long FACTS_CACHE_TTL_MS = 12L * 60L * 60L * 1000L;
+    private static final long FACTS_CACHE_TTL_MS = 3L * 24L * 60L * 60L * 1000L;
 
 
 


### PR DESCRIPTION
…cts to improve performance and reduce redundant data fetching.

- **BirdCacheManager**:
    - Increased the core bird list cache TTL (`CORE_BIRD_LIST_CACHE_TTL_MS`) from 12 hours to 24 hours.
    - Extended the bird details cache TTL (`BIRD_DETAILS_CACHE_TTL_MS`) from 12 hours to 3 days.
- **BirdWikiActivity**:
    - Extended the local facts cache TTL (`FACTS_CACHE_TTL_MS`) from 12 hours to 3 days to minimize Cloud Function calls.