### PR TITLE
Updated post and comment option menus to restrict the "Report" action…

### DIFF
--- a/app/src/main/java/com/birddex/app/ForumFragment.java
+++ b/app/src/main/java/com/birddex/app/ForumFragment.java
@@ -478,7 +478,7 @@ public class ForumFragment extends Fragment implements ForumPostAdapter.OnPostCl
         FirebaseUser u = mAuth.getCurrentUser();
         if (u != null && p.getUserId().equals(u.getUid())) popup.getMenu().add("Delete");
         popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
-        popup.getMenu().add("Report");
+        if (u != null && !p.getUserId().equals(u.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(p);
             else if (item.getTitle().equals("Save Post")) savePostForLater(p);

--- a/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
+++ b/app/src/main/java/com/birddex/app/NearbyHeatmapActivity.java
@@ -59,6 +59,7 @@ import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.Source;
 import com.google.firebase.firestore.WriteBatch;
@@ -729,7 +730,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         FirebaseUser user = mAuth.getCurrentUser();
         if (user != null && p.getUserId().equals(user.getUid())) popup.getMenu().add("Delete");
         popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
-        popup.getMenu().add("Report");
+        if (user != null && !p.getUserId().equals(user.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(p, dialog);
             else if (item.getTitle().equals("Save Post")) savePostForLater(p);
@@ -996,7 +997,7 @@ public class NearbyHeatmapActivity extends AppCompatActivity
         PopupMenu p = new PopupMenu(this, v);
         FirebaseUser user = mAuth.getCurrentUser();
         if (user != null && c.getUserId().equals(user.getUid())) p.getMenu().add("Delete");
-        p.getMenu().add("Report");
+        if (user != null && !c.getUserId().equals(user.getUid())) p.getMenu().add("Report");
         p.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showCommentDeleteConfirmation(c);
             else if (item.getTitle().equals("Report")) showReportDialog("comment", c.getId());

--- a/app/src/main/java/com/birddex/app/PostDetailActivity.java
+++ b/app/src/main/java/com/birddex/app/PostDetailActivity.java
@@ -390,7 +390,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
             popup.getMenu().add("Delete");
         }
         popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
-        popup.getMenu().add("Report");
+        if (user != null && !post.getUserId().equals(user.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Edit")) showEditPostDialog(post);
             else if (item.getTitle().equals("Delete")) showDeleteConfirmation(post);
@@ -831,7 +831,7 @@ public class PostDetailActivity extends AppCompatActivity implements ForumCommen
             if (c.getTimestamp() != null && (System.currentTimeMillis() - c.getTimestamp().toDate().getTime() <= EDIT_WINDOW_MS)) popup.getMenu().add("Edit");
             popup.getMenu().add("Delete");
         }
-        popup.getMenu().add("Report");
+        if (user != null && !c.getUserId().equals(user.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Edit")) showEditCommentDialog(c);
             else if (item.getTitle().equals("Delete")) showCommentDeleteConfirmation(c);

--- a/app/src/main/java/com/birddex/app/ProfileFragment.java
+++ b/app/src/main/java/com/birddex/app/ProfileFragment.java
@@ -988,9 +988,10 @@ public class ProfileFragment extends Fragment implements
 
     private void showResolvedPostOptions(ForumPost post, View view, boolean isSaved) {
         PopupMenu popup = new PopupMenu(requireContext(), view);
-        if (mAuth.getUid() != null && mAuth.getUid().equals(post.getUserId())) popup.getMenu().add("Delete");
+        FirebaseUser user = mAuth.getCurrentUser();
+        if (user != null && post.getUserId().equals(user.getUid())) popup.getMenu().add("Delete");
         popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
-        popup.getMenu().add("Report");
+        if (user != null && !post.getUserId().equals(user.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) showDeleteConfirmation(post);
             else if (item.getTitle().equals("Save Post")) savePostForLater(post);

--- a/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
+++ b/app/src/main/java/com/birddex/app/UserSocialProfileActivity.java
@@ -609,7 +609,7 @@ public class UserSocialProfileActivity extends AppCompatActivity implements
             popup.getMenu().add("Delete");
         }
         popup.getMenu().add(isSaved ? "Unsave Post" : "Save Post");
-        popup.getMenu().add("Report");
+        if (currentUser != null && !post.getUserId().equals(currentUser.getUid())) popup.getMenu().add("Report");
         popup.setOnMenuItemClickListener(item -> {
             if (item.getTitle().equals("Delete")) {
                 new AlertDialog.Builder(this)


### PR DESCRIPTION
… and ensure proper user authentication checks across multiple activities.

### **UI & Logic Enhancements**:
- **Reporting Restrictions**:
    - Modified `ForumFragment`, `PostDetailActivity`, `ProfileFragment`, `NearbyHeatmapActivity`, and `UserSocialProfileActivity` to hide the "Report" option for a user's own posts and comments.
    - Added checks to ensure the "Report" option only appears if a user is logged in and is not the author of the content.
- **Authentication Handling**:
    - Standardized `FirebaseUser` retrieval and null checks before populating popup menus for posts and comments.
    - Refactored `ProfileFragment` to use a local `FirebaseUser` variable for consistency when checking ownership of resolved posts.

### **Clean-up**:
- Added a missing `MetadataChanges` import in `NearbyHeatmapActivity`.
- Removed unnecessary trailing whitespace in `ProfileFragment`.