### PR TITLE
Removed the "Captured by you" footer from bird card views.

### DIFF
--- a/app/src/main/java/com/birddex/app/ViewBirdCardActivity.java
+++ b/app/src/main/java/com/birddex/app/ViewBirdCardActivity.java
@@ -170,9 +170,6 @@ public class ViewBirdCardActivity extends AppCompatActivity {
         txtLocation = findViewById(R.id.txtLocation);
         txtDateCaught = findViewById(R.id.txtDateCaught);
 
-        View txtFooter = findViewById(R.id.txtFooter);
-        if (txtFooter != null) txtFooter.setVisibility(View.VISIBLE);
-
         String name = getIntent().getStringExtra(CollectionCardAdapter.EXTRA_COMMON_NAME);
         String sci = getIntent().getStringExtra(CollectionCardAdapter.EXTRA_SCI_NAME);
         TextView txtBirdName = findViewById(R.id.txtBirdName);

--- a/app/src/main/res/layout/view_bird_card_epic.xml
+++ b/app/src/main/res/layout/view_bird_card_epic.xml
@@ -112,6 +112,7 @@
                     android:text="BirdDex • Captured by you"
                     android:textColor="#FFFFFF"
                     android:textSize="16sp"
+                    android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@id/statsRow"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/view_bird_card_legendary.xml
+++ b/app/src/main/res/layout/view_bird_card_legendary.xml
@@ -112,6 +112,7 @@
                     android:text="BirdDex • Captured by you"
                     android:textColor="#FFFFFF"
                     android:textSize="16sp"
+                    android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@id/statsRow"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/view_bird_card_mythic.xml
+++ b/app/src/main/res/layout/view_bird_card_mythic.xml
@@ -112,6 +112,7 @@
                     android:text="BirdDex • Captured by you"
                     android:textColor="#FFFFFF"
                     android:textSize="16sp"
+                    android:visibility="gone"
                     app:layout_constraintTop_toBottomOf="@id/statsRow"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
### **Changes**:
- **Layouts**: Updated `view_bird_card_legendary.xml`, `view_bird_card_mythic.xml`, and `view_bird_card_epic.xml` to set the footer text visibility to `gone`.
- **Logic**: Removed programmatic visibility overrides for `txtFooter` in `ViewBirdCardActivity.java`.