### PR TITLE
Implemented a visual evidence system for moderation events and appeal…

### DIFF
--- a/app/src/main/java/com/birddex/app/ModerationHistoryActivity.java
+++ b/app/src/main/java/com/birddex/app/ModerationHistoryActivity.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -13,9 +14,11 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
 import com.google.android.material.button.MaterialButton;
 
 import java.text.SimpleDateFormat;
@@ -104,7 +107,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
         if (state.get("strikeCount") instanceof Number) {
             strikes = ((Number) state.get("strikeCount")).longValue();
         }
-        
+
         boolean isPermBan = Boolean.TRUE.equals(state.get("permanentForumBan"));
         Object suspendedUntil = state.get("forumSuspendedUntil");
 
@@ -159,7 +162,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
         final EditText input = new EditText(this);
         input.setHint(R.string.hint_appeal_reason);
         input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
-        
+
         FrameLayout container = new FrameLayout(this);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         params.leftMargin = 48;
@@ -212,10 +215,71 @@ public class ModerationHistoryActivity extends AppCompatActivity {
                 date = new Date(((Number) map.get("_seconds")).longValue() * 1000);
             }
         }
-        
+
         if (date == null) return "N/A";
         SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault());
         return sdf.format(date);
+    }
+
+
+    private static void bindEvidenceImage(ImageView imageView, Map<String, Object> data, String... keys) {
+        String url = null;
+        if (data != null && keys != null) {
+            for (String key : keys) {
+                Object value = data.get(key);
+                if (value instanceof String && !((String) value).trim().isEmpty()) {
+                    url = ((String) value).trim();
+                    break;
+                }
+            }
+        }
+
+        if (url == null || url.isEmpty()) {
+            imageView.setVisibility(View.GONE);
+            imageView.setOnClickListener(null);
+            return;
+        }
+
+        imageView.setVisibility(View.VISIBLE);
+        Glide.with(imageView.getContext())
+                .load(url)
+                .placeholder(R.drawable.bg_image_placeholder)
+                .error(R.drawable.bg_image_placeholder)
+                .into(imageView);
+
+        final String finalUrl = url;
+        imageView.setOnClickListener(v -> showEvidenceImageDialog(v.getContext(), finalUrl));
+    }
+
+    private static void showEvidenceImageDialog(android.content.Context context, String imageUrl) {
+        if (context == null || imageUrl == null || imageUrl.trim().isEmpty()) {
+            return;
+        }
+
+        ImageView imageView = new ImageView(context);
+        imageView.setAdjustViewBounds(true);
+        imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        int padding = Math.round(context.getResources().getDisplayMetrics().density * 16f);
+        imageView.setPadding(padding, padding, padding, padding);
+
+        Glide.with(context)
+                .load(imageUrl)
+                .placeholder(R.drawable.bg_image_placeholder)
+                .error(R.drawable.bg_image_placeholder)
+                .into(imageView);
+
+        CardView container = new CardView(context);
+        container.setRadius(Math.round(context.getResources().getDisplayMetrics().density * 18f));
+        container.addView(imageView, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        new AlertDialog.Builder(context)
+                .setTitle("Flagged image")
+                .setView(container)
+                .setPositiveButton("Close", null)
+                .show();
     }
 
     // --- Inner Adapter Class for Events ---
@@ -246,23 +310,24 @@ public class ModerationHistoryActivity extends AppCompatActivity {
             Map<String, Object> event = events.get(position);
             String actionType = (String) event.get("actionType");
             holder.tvType.setText(actionType != null ? actionType.replace("_", " ").toUpperCase() : "UNKNOWN");
-            
+
             StringBuilder reasonDetails = new StringBuilder("Reason: ").append(event.get("reasonCode"));
             Object expiresAt = event.get("expiresAt");
             if (expiresAt != null) {
                 reasonDetails.append("\nExpires: ").append(formatTimestamp(expiresAt));
             }
             holder.tvReason.setText(reasonDetails.toString());
-            
+
             String status = (String) event.get("status");
             holder.tvStatus.setText("Status: " + (status != null ? status : "active"));
-            
+
             holder.tvDate.setText("Created: " + formatTimestamp(event.get("createdAt")));
-            
+            bindEvidenceImage(holder.ivEvidenceImage, event, "evidenceImageUrl", "snapshotEvidenceImageUrl");
+
             Object id = event.get("id");
             if (id == null) id = event.get("eventId");
             String eventIdStr = id != null ? id.toString() : null;
-            
+
             boolean alreadyAppealed = eventIdStr != null && appealedEventIds.contains(eventIdStr);
             boolean appealable = Boolean.TRUE.equals(event.get("appealable"));
 
@@ -287,6 +352,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
         static class ViewHolder extends RecyclerView.ViewHolder {
             TextView tvType, tvReason, tvStatus, tvDate;
             MaterialButton btnAppeal;
+            ImageView ivEvidenceImage;
             ViewHolder(View v) {
                 super(v);
                 tvType = v.findViewById(R.id.tvActionType);
@@ -294,6 +360,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
                 tvStatus = v.findViewById(R.id.tvStatus);
                 tvDate = v.findViewById(R.id.tvDate);
                 btnAppeal = v.findViewById(R.id.btnAppeal);
+                ivEvidenceImage = v.findViewById(R.id.ivEvidenceImage);
             }
         }
     }
@@ -317,15 +384,33 @@ public class ModerationHistoryActivity extends AppCompatActivity {
         @Override
         public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
             Map<String, Object> appeal = appeals.get(position);
+            String actionType = String.valueOf(appeal.get("snapshotActionType") != null
+                    ? appeal.get("snapshotActionType")
+                    : "appeal");
+            String reasonCode = String.valueOf(appeal.get("snapshotReasonCode") != null
+                    ? appeal.get("snapshotReasonCode")
+                    : "unknown");
+            String reasonText = appeal.get("snapshotReasonText") instanceof String
+                    ? ((String) appeal.get("snapshotReasonText")).trim()
+                    : "";
+
             holder.tvType.setText("APPEAL");
-            holder.tvReason.setText("Text: " + appeal.get("appealText"));
-            
+            StringBuilder reasonBuilder = new StringBuilder();
+            reasonBuilder.append("Decision: ").append(actionType.replace("_", " ").toUpperCase(Locale.getDefault()));
+            reasonBuilder.append("\nCode: ").append(reasonCode.replace("_", " "));
+            reasonBuilder.append("\nAppeal: ").append(String.valueOf(appeal.get("appealText")));
+            if (!reasonText.isEmpty()) {
+                reasonBuilder.append("\nOriginal reason: ").append(reasonText);
+            }
+            holder.tvReason.setText(reasonBuilder.toString());
+
             String status = (String) appeal.get("status");
             holder.tvStatus.setText("Status: " + (status != null ? status : "pending"));
             holder.tvDate.setText("Submitted: " + formatTimestamp(appeal.get("createdAt")));
-            
+
             holder.btnAppeal.setVisibility(View.GONE);
-            
+            bindEvidenceImage(holder.ivEvidenceImage, appeal, "snapshotEvidenceImageUrl", "evidenceImageUrl");
+
             if ("denied".equals(status) && appeal.containsKey("decisionNote")) {
                 holder.tvStatus.setText(holder.tvStatus.getText() + "\nNote: " + appeal.get("decisionNote"));
             } else if ("approved".equals(status)) {
@@ -339,6 +424,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
         static class ViewHolder extends RecyclerView.ViewHolder {
             TextView tvType, tvReason, tvStatus, tvDate;
             MaterialButton btnAppeal;
+            ImageView ivEvidenceImage;
             ViewHolder(View v) {
                 super(v);
                 tvType = v.findViewById(R.id.tvActionType);
@@ -346,6 +432,7 @@ public class ModerationHistoryActivity extends AppCompatActivity {
                 tvStatus = v.findViewById(R.id.tvStatus);
                 tvDate = v.findViewById(R.id.tvDate);
                 btnAppeal = v.findViewById(R.id.btnAppeal);
+                ivEvidenceImage = v.findViewById(R.id.ivEvidenceImage);
             }
         }
     }

--- a/app/src/main/java/com/birddex/app/ModeratorActivity.java
+++ b/app/src/main/java/com/birddex/app/ModeratorActivity.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -13,9 +14,11 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
 import com.google.android.material.button.MaterialButton;
 
 import java.text.SimpleDateFormat;
@@ -316,6 +319,67 @@ public class ModeratorActivity extends AppCompatActivity {
         });
     }
 
+
+    private static void bindEvidenceImage(ImageView imageView, Map<String, Object> data, String... keys) {
+        String url = null;
+        if (data != null && keys != null) {
+            for (String key : keys) {
+                Object value = data.get(key);
+                if (value instanceof String && !((String) value).trim().isEmpty()) {
+                    url = ((String) value).trim();
+                    break;
+                }
+            }
+        }
+
+        if (url == null || url.isEmpty()) {
+            imageView.setVisibility(View.GONE);
+            imageView.setOnClickListener(null);
+            return;
+        }
+
+        imageView.setVisibility(View.VISIBLE);
+        Glide.with(imageView.getContext())
+                .load(url)
+                .placeholder(R.drawable.bg_image_placeholder)
+                .error(R.drawable.bg_image_placeholder)
+                .into(imageView);
+
+        final String finalUrl = url;
+        imageView.setOnClickListener(v -> showEvidenceImageDialog(v.getContext(), finalUrl));
+    }
+
+    private static void showEvidenceImageDialog(android.content.Context context, String imageUrl) {
+        if (context == null || imageUrl == null || imageUrl.trim().isEmpty()) {
+            return;
+        }
+
+        ImageView imageView = new ImageView(context);
+        imageView.setAdjustViewBounds(true);
+        imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        int padding = Math.round(context.getResources().getDisplayMetrics().density * 16f);
+        imageView.setPadding(padding, padding, padding, padding);
+
+        Glide.with(context)
+                .load(imageUrl)
+                .placeholder(R.drawable.bg_image_placeholder)
+                .error(R.drawable.bg_image_placeholder)
+                .into(imageView);
+
+        CardView container = new CardView(context);
+        container.setRadius(Math.round(context.getResources().getDisplayMetrics().density * 18f));
+        container.addView(imageView, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        new AlertDialog.Builder(context)
+                .setTitle("Flagged image")
+                .setView(container)
+                .setPositiveButton("Close", null)
+                .show();
+    }
+
     private static String mapSelectedUserAction(int which) {
         switch (which) {
             case 1:
@@ -460,14 +524,23 @@ public class ModeratorActivity extends AppCompatActivity {
         private void bindAppeal(@NonNull ViewHolder holder, Map<String, Object> appeal) {
             String actionType = formatModerationValue(getDisplayValue(appeal, "snapshotActionType", "Unknown"));
             String reasonCode = formatModerationValue(getDisplayValue(appeal, "snapshotReasonCode", "Unknown"));
+            String reasonText = truncate(getDisplayValue(appeal, "snapshotReasonText", ""), 180);
             String userId = getDisplayValue(appeal, "userId", "Unknown");
             String appealText = truncate(getDisplayValue(appeal, "appealText", "No appeal text provided."), 180);
 
             holder.tvType.setText("PENDING APPEAL");
-            holder.tvReason.setText("User ID: " + userId + "\nAction: " + actionType + "\nAppeal: " + appealText);
+            StringBuilder reasonBuilder = new StringBuilder();
+            reasonBuilder.append("User ID: ").append(userId);
+            reasonBuilder.append("\nAction: ").append(actionType);
+            reasonBuilder.append("\nAppeal: ").append(appealText);
+            if (!reasonText.isEmpty()) {
+                reasonBuilder.append("\nOriginal reason: ").append(reasonText);
+            }
+            holder.tvReason.setText(reasonBuilder.toString());
             holder.tvStatus.setText("Reason Code: " + reasonCode);
             holder.tvDate.setText("Submitted: " + formatTimestamp(appeal.get("createdAt")));
             holder.btnAppeal.setText("Review Appeal");
+            bindEvidenceImage(holder.ivEvidenceImage, appeal, "snapshotEvidenceImageUrl", "evidenceImageUrl");
         }
 
         private void bindReport(@NonNull ViewHolder holder, Map<String, Object> report) {
@@ -498,6 +571,7 @@ public class ModeratorActivity extends AppCompatActivity {
             holder.tvStatus.setText(statusBuilder.toString());
             holder.tvDate.setText("Reported: " + formatTimestamp(report.get("timestamp")));
             holder.btnAppeal.setText("Review Report");
+            bindEvidenceImage(holder.ivEvidenceImage, report, "evidenceImageUrl", "snapshotEvidenceImageUrl");
         }
 
         @Override
@@ -508,6 +582,7 @@ public class ModeratorActivity extends AppCompatActivity {
         static class ViewHolder extends RecyclerView.ViewHolder {
             TextView tvType, tvReason, tvStatus, tvDate;
             MaterialButton btnAppeal;
+            ImageView ivEvidenceImage;
 
             ViewHolder(View v) {
                 super(v);
@@ -516,6 +591,7 @@ public class ModeratorActivity extends AppCompatActivity {
                 tvStatus = v.findViewById(R.id.tvStatus);
                 tvDate = v.findViewById(R.id.tvDate);
                 btnAppeal = v.findViewById(R.id.btnAppeal);
+                ivEvidenceImage = v.findViewById(R.id.ivEvidenceImage);
             }
         }
     }

--- a/app/src/main/res/layout/activity_moderation_history.xml
+++ b/app/src/main/res/layout/activity_moderation_history.xml
@@ -156,6 +156,14 @@
                 </androidx.cardview.widget.CardView>
             </LinearLayout>
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:text="Rejected forum images appear in the moderation cards below. Tap an image to enlarge it."
+                android:textColor="@color/on_page_variant"
+                android:textSize="12sp" />
+
             <!-- Pending Appeals Section -->
             <TextView
                 android:id="@+id/labelAppeals"

--- a/app/src/main/res/layout/activity_moderator.xml
+++ b/app/src/main/res/layout/activity_moderator.xml
@@ -40,7 +40,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="2dp"
         android:layout_marginEnd="16dp"
-        android:text="Review pending moderation appeals and reports."
+        android:text="Review pending moderation appeals and reports. Rejected images appear in each card and can be tapped to enlarge."
         android:textColor="@color/on_page_variant"
         android:textSize="13sp"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_moderation_event.xml
+++ b/app/src/main/res/layout/item_moderation_event.xml
@@ -15,6 +15,19 @@
         android:orientation="vertical"
         android:padding="12dp">
 
+        <ImageView
+            android:id="@+id/ivEvidenceImage"
+            android:layout_width="match_parent"
+            android:layout_height="180dp"
+            android:layout_marginBottom="8dp"
+            android:contentDescription="Flagged evidence image"
+            android:foreground="?attr/selectableItemBackground"
+            android:scaleType="centerCrop"
+            android:visibility="gone"
+            tools:src="@drawable/bg_image_placeholder"
+            tools:visibility="visible" />
+
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/functions/index.js
+++ b/functions/index.js
@@ -3247,7 +3247,7 @@ exports.getMyModerationState = onCall(async (request) => {
         db.collection("moderationAppeals").where("userId", "==", userId).limit(25).get(),
     ]);
 
-    const events = eventsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const events = eventsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() })); // evidenceImageUrl is forwarded automatically via the document spread (moderation-image-evidence)
     events.sort((a, b) => (timestampToMillis(b.createdAt) || 0) - (timestampToMillis(a.createdAt) || 0));
 
     const appeals = appealsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
@@ -3329,6 +3329,8 @@ exports.submitModerationAppeal = onCall(async (request) => {
                 decisionNote: null,
                 snapshotActionType: eventData.actionType || null,
                 snapshotReasonCode: eventData.reasonCode || null,
+                snapshotReasonText: eventData.reasonText || null,
+                snapshotEvidenceImageUrl: eventData.evidenceImageUrl || null,
             });
         });
 
@@ -3354,7 +3356,36 @@ exports.getPendingModerationAppeals = onCall(async (request) => {
         .limit(100)
         .get();
 
-    const appeals = appealsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const appeals = await Promise.all(appealsSnap.docs.map(async (doc) => {
+        const data = doc.data() || {};
+        const moderationEventId = sanitizeText(data.moderationEventId || "", 200).trim();
+
+        let linkedEventData = {};
+        if (moderationEventId) {
+            try {
+                const linkedEventSnap = await db.collection("moderationEvents").doc(moderationEventId).get();
+                if (linkedEventSnap.exists) {
+                    linkedEventData = linkedEventSnap.data() || {};
+                }
+            } catch (error) {
+                logger.warn("getPendingModerationAppeals: failed to fetch linked moderation event", error);
+            }
+        }
+
+        return {
+            id: doc.id,
+            ...data,
+            snapshotReasonText: sanitizeText(
+                data.snapshotReasonText || linkedEventData.reasonText || "",
+                500
+            ) || null,
+            snapshotEvidenceImageUrl: typeof data.snapshotEvidenceImageUrl === "string" && data.snapshotEvidenceImageUrl.trim()
+                ? data.snapshotEvidenceImageUrl.trim()
+                : (typeof linkedEventData.evidenceImageUrl === "string" && linkedEventData.evidenceImageUrl.trim()
+                    ? linkedEventData.evidenceImageUrl.trim()
+                    : null),
+        };
+    }));
     appeals.sort((a, b) => (timestampToMillis(b.createdAt) || 0) - (timestampToMillis(a.createdAt) || 0));
 
     return {
@@ -3417,6 +3448,22 @@ exports.getPendingModerationReports = onCall(async (request) => {
             }
         }
 
+        let evidenceImageUrl = null;
+        if (data.targetId) {
+            try {
+                const evSnap = await db.collection("moderationEvents")
+                    .where("targetId", "==", data.targetId)
+                    .where("actionType", "==", "reject_content")
+                    .limit(1)
+                    .get();
+                if (!evSnap.empty) {
+                    evidenceImageUrl = evSnap.docs[0].data().evidenceImageUrl || null;
+                }
+            } catch (e) {
+                logger.warn("getPendingModerationReports: failed to fetch evidenceImageUrl", e);
+            }
+        }
+
         return {
             id: doc.id,
             ...data,
@@ -3428,6 +3475,7 @@ exports.getPendingModerationReports = onCall(async (request) => {
             targetModerationStatus,
             currentUniqueReporterCount,
             currentReportCount,
+            evidenceImageUrl,
         };
     }));
 
@@ -4584,6 +4632,7 @@ function buildModerationEventPayload({
     appealable = false,
     expiresAt = null,
     metadata = {},
+    evidenceImageUrl = null,
 }) {
     return {
         eventId,
@@ -4603,6 +4652,7 @@ function buildModerationEventPayload({
         reviewedBy: null,
         reversalReason: null,
         metadata: metadata || {},
+        evidenceImageUrl: evidenceImageUrl || null,
     };
 }
 
@@ -5215,6 +5265,7 @@ exports.createForumPost = onCall(async (request) => {
             });
 
             const contentEventRef = createModerationEventRef();
+            const evidenceImageUrl = imageModeration.archivedUrl || birdImageUrl;
             t.set(contentEventRef, buildModerationEventPayload({
                 eventId: contentEventRef.id,
                 userId,
@@ -5225,6 +5276,7 @@ exports.createForumPost = onCall(async (request) => {
                 reasonText: `Forum image upload was blocked by SafeSearch. ${imageModeration.reasonText}`,
                 source: "vision_safesearch",
                 appealable: true,
+                evidenceImageUrl,
                 metadata: {
                     penaltyType: penaltySummary.penaltyType,
                     linkedModerationEventIds: Array.isArray(penaltySummary.linkedModerationEventIds)


### PR DESCRIPTION
…s, allowing moderators and users to view flagged images directly within the moderation interface.

### **Moderation & Backend Enhancements**:
- **Evidence Tracking**: Updated Cloud Functions to capture and store `evidenceImageUrl` and `reasonText` snapshots when moderation events are created, particularly for Vision SafeSearch blocks.
- **Data Linking**: Enhanced `getPendingModerationAppeals` and `getPendingModerationReports` to dynamically fetch linked moderation event data (images and reasons) if they are missing from the primary document.
- **Payload Updates**: Modified `buildModerationEventPayload` and automated forum image moderation logic to include the `evidenceImageUrl` (archived URL or original image URL).

### **User Interface & Experience**:
- **Evidence Image Support**: Added an `ivEvidenceImage` (ImageView) to moderation event cards in both `ModeratorActivity` and `ModerationHistoryActivity`.
- **Image Preview**: Implemented a `bindEvidenceImage` utility that uses Glide to load flagged images and opens a centered, high-resolution `AlertDialog` preview when the image is tapped.
- **Enhanced Descriptions**: Updated the UI layouts for `activity_moderator` and `activity_moderation_history` with instructional text explaining how to view and enlarge rejected forum images.
- **Detailed History**: Improved the appeal view in `ModerationHistoryActivity` to display the original reason code and text alongside the user's appeal text for better context.

### **Technical Refinement**:
- **Sanitization**: Integrated `sanitizeText` for `snapshotReasonText` in backend functions to ensure data consistency.
- **Robustness**: Added error handling for linked document fetches in Cloud Functions to prevent failures when a related moderation event is missing.