### PR TITLE
Optimized UI performance and navigation state management by implementing fragment caching and reducing redundant network requests across major application screens.

### DIFF
--- a/app/src/main/java/com/birddex/app/HomeActivity.java
+++ b/app/src/main/java/com/birddex/app/HomeActivity.java
@@ -43,6 +43,10 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
     private static final String TAG = "HomeActivity";
     private static final long GEORGIA_SYNC_CHECK_TTL_MS = 24L * 60L * 60L * 1000L;
     private static final int GEORGIA_BIRD_DATA_REFRESH_VERSION = 1;
+    private static final String TAG_FORUM = "tab_forum";
+    private static final String TAG_COLLECTION = "tab_collection";
+    private static final String TAG_NEARBY = "tab_nearby";
+    private static final String TAG_PROFILE = "tab_profile";
 
     private BottomNavigationView bottomNav;
     private View bottomNavContainer;
@@ -60,6 +64,7 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
     private boolean isFetchingBirds = false; // Flag to prevent redundant fetches
     private boolean isNavigating = false;
     private boolean welcomeCheckedThisResume = false;
+    private String currentFragmentTag = null;
 
     /**
      * Android calls this when the Activity is first created. This is where the screen usually
@@ -108,7 +113,7 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
         if (getSupportFragmentManager().findFragmentById(R.id.fragmentContainer) == null) {
             lastNonCameraTabId = R.id.nav_forum;
             bottomNav.setSelectedItemId(R.id.nav_forum);
-            switchFragment(new ForumFragment());
+            switchFragmentForTab(R.id.nav_forum);
         }
 
         // Set up the listener for navigation item selection.
@@ -130,19 +135,19 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
                 return false;
             } else if (id == R.id.nav_search_collection) {
                 lastNonCameraTabId = id;
-                switchFragment(new SearchCollectionFragment());
+                switchFragmentForTab(id);
                 return true;
             } else if (id == R.id.nav_forum) {
                 lastNonCameraTabId = id;
-                switchFragment(new ForumFragment());
+                switchFragmentForTab(id);
                 return true;
             } else if (id == R.id.nav_nearby) {
                 lastNonCameraTabId = id;
-                switchFragment(new NearbyFragment());
+                switchFragmentForTab(id);
                 return true;
             } else if (id == R.id.nav_profile) {
                 lastNonCameraTabId = id;
-                switchFragment(new ProfileFragment());
+                switchFragmentForTab(id);
                 return true;
             }
 
@@ -282,7 +287,7 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
             String targetUserId = intent.getStringExtra("target_user_id");
             lastNonCameraTabId = R.id.nav_profile;
             bottomNav.setSelectedItemId(R.id.nav_profile);
-            switchFragment(ProfileFragment.newInstance(targetUserId));
+            switchFragment(ProfileFragment.newInstance(targetUserId), TAG_PROFILE + ":" + targetUserId);
         }
     }
 
@@ -426,13 +431,49 @@ public class HomeActivity extends AppCompatActivity implements NetworkMonitor.Ne
     /**
      * Main logic block for this part of the feature.
      */
-    private void switchFragment(Fragment fragment) {
+    private void switchFragment(Fragment fragment, String tag) {
         if (isFinishing() || isDestroyed()) return;
 
-        getSupportFragmentManager()
-                .beginTransaction()
-                .replace(R.id.fragmentContainer, fragment)
-                .commitAllowingStateLoss();
+        if (tag != null && tag.equals(currentFragmentTag)) {
+            return;
+        }
+
+        androidx.fragment.app.FragmentTransaction tx = getSupportFragmentManager().beginTransaction();
+
+        Fragment current = currentFragmentTag == null
+                ? null
+                : getSupportFragmentManager().findFragmentByTag(currentFragmentTag);
+        if (current != null) {
+            tx.hide(current);
+        }
+
+        Fragment target = getSupportFragmentManager().findFragmentByTag(tag);
+        if (target == null) {
+            tx.add(R.id.fragmentContainer, fragment, tag);
+        } else {
+            tx.show(target);
+        }
+
+        currentFragmentTag = tag;
+        tx.commitAllowingStateLoss();
+    }
+
+    private void switchFragmentForTab(int tabId) {
+        if (tabId == R.id.nav_search_collection) {
+            switchFragment(new SearchCollectionFragment(), TAG_COLLECTION);
+            return;
+        }
+        if (tabId == R.id.nav_forum) {
+            switchFragment(new ForumFragment(), TAG_FORUM);
+            return;
+        }
+        if (tabId == R.id.nav_nearby) {
+            switchFragment(new NearbyFragment(), TAG_NEARBY);
+            return;
+        }
+        if (tabId == R.id.nav_profile) {
+            switchFragment(new ProfileFragment(), TAG_PROFILE);
+        }
     }
 
     // You can add a method here to provide the allGeorgiaBirds list to fragments if they need it

--- a/app/src/main/java/com/birddex/app/ProfileFragment.java
+++ b/app/src/main/java/com/birddex/app/ProfileFragment.java
@@ -207,10 +207,19 @@ public class ProfileFragment extends Fragment implements
         super.onResume();
         isNavigating = false;
         if (profileListener == null) fetchUserProfile();
-        refreshPosts();
+
+        // Keep tab content in place when returning from child screens. Only fetch if we
+        // truly have no local content yet.
+        if (postList.isEmpty() && !isFetching && !isLastPage) {
+            refreshPosts();
+        }
         if (isCurrentUser) {
-            refreshTrackedBirds();
-            refreshSavedPosts();
+            if (trackedBirdList.isEmpty()) {
+                refreshTrackedBirds();
+            }
+            if (savedPostList.isEmpty() && !isFetchingSaved && !isSavedLastPage) {
+                refreshSavedPosts();
+            }
         }
     }
 

--- a/app/src/main/java/com/birddex/app/SearchCollectionFragment.java
+++ b/app/src/main/java/com/birddex/app/SearchCollectionFragment.java
@@ -148,8 +148,16 @@ public class SearchCollectionFragment extends Fragment {
         super.onResume();
         isNavigating = false;
         if (cardAdapter != null) cardAdapter.setNavigating(false);
-        fetchUserCollection();
-        if (currentViewMode == ViewMode.RECENT_PHOTOS) fetchRecentPhotos();
+        // Keep loaded data when coming back to this tab; only fetch if we have nothing yet.
+        if (rawSlots.isEmpty()) {
+            fetchUserCollection();
+        } else {
+            applyCurrentFilter();
+        }
+
+        if (currentViewMode == ViewMode.RECENT_PHOTOS && recentPhotoEntries.isEmpty()) {
+            fetchRecentPhotos();
+        }
     }
 
     /**

--- a/app/src/main/java/com/birddex/app/SettingsActivity.java
+++ b/app/src/main/java/com/birddex/app/SettingsActivity.java
@@ -187,8 +187,19 @@ public class SettingsActivity extends AppCompatActivity {
 
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         if (user != null) {
-            loadUserProfile(user);
-            fetchIdentificationsRemaining();
+            // Avoid visual "popping" on every back navigation. Refresh only if the screen
+            // does not already have loaded values.
+            boolean needsProfileReload = tvUserName.getText() == null
+                    || tvUserName.getText().toString().trim().isEmpty();
+            boolean needsQuotaReload = tvIdentificationsRemaining.getText() == null
+                    || tvIdentificationsRemaining.getText().toString().trim().isEmpty();
+
+            if (needsProfileReload) {
+                loadUserProfile(user);
+            }
+            if (needsQuotaReload) {
+                fetchIdentificationsRemaining();
+            }
         }
     }
 


### PR DESCRIPTION

### **Navigation & Fragment Management**
- **Fragment State Preservation**: Refactored `HomeActivity` to use a hide/show strategy with fragment tags (`TAG_FORUM`, `TAG_COLLECTION`, etc.) instead of replacing fragments. This preserves the scroll position and UI state when switching between bottom navigation tabs.
- **Dynamic Tab Switching**: Introduced `switchFragmentForTab` to centralize fragment instantiation and tag management for main navigation hubs.

### **Performance & Data Fetching**
- **Conditional Refreshing**: Updated `onResume` logic in `ProfileFragment`, `SearchCollectionFragment`, and `SettingsActivity` to check if data already exists before triggering new network fetches.
- **Redundant Load Prevention**: 
    - In `ProfileFragment`, posts, tracked birds, and saved posts are now only fetched if their respective lists are empty.
    - In `SearchCollectionFragment`, the collection is only re-fetched if the local cache is empty; otherwise, the current filter is re-applied to existing data.
    - In `SettingsActivity`, user profile and identification quota updates are skipped if the UI components already contain populated data, preventing visual "popping" during back navigation.